### PR TITLE
Fix compiler warnings caused by -Wall and -Wextra

### DIFF
--- a/.vscode/.gitignore
+++ b/.vscode/.gitignore
@@ -1,0 +1,1 @@
+settings.json

--- a/include/Entity.h
+++ b/include/Entity.h
@@ -68,7 +68,7 @@ public:
 
     void gravcreate(Game& game, int ypos, int dir, int xoff = 0, int yoff = 0);
 
-    void generateswnwave(Game& game, UtilityClass& help, int t);
+    void generateswnwave(Game& game, int t);
 
     void createblock(int t, int xp, int yp, int w, int h, int trig = 0);
 
@@ -99,11 +99,11 @@ public:
 
     bool updateentities(int i, UtilityClass& help, Game& game, musicclass& music);
 
-    void animateentities(int i, Game& game, UtilityClass& help);
+    void animateentities(int i, Game& game);
 
     bool gettype(int t);
 
-    int getcompanion(int t);
+    int getcompanion();
 
     int getplayer();
 
@@ -122,7 +122,7 @@ public:
 
     bool entitycollide(int a, int b);
 
-    bool checkdirectional(int t);
+    bool checkdirectional();
 
     bool checkdamage();
 
@@ -159,9 +159,9 @@ public:
 
 		void customwarplinecheck(int i);
 
-    float entitycollideplatformroof(mapclass& map, int t);
+    float entitycollideplatformroof(int t);
 
-    float entitycollideplatformfloor(mapclass& map, int t);
+    float entitycollideplatformfloor(int t);
 
     bool entitycollidefloor(mapclass& map, int t);
 
@@ -186,7 +186,7 @@ public:
 
     void scmmovingplatformfix(int t, mapclass& map);
 
-    void hormovingplatformfix(int t, mapclass& map);
+    void hormovingplatformfix(int t);
 
     void entitycollisioncheck(Graphics& dwgfx, Game& game, mapclass& map, musicclass& music);
 

--- a/include/FileSystemUtils.h
+++ b/include/FileSystemUtils.h
@@ -10,7 +10,7 @@ void FILESYSTEM_deinit();
 char *FILESYSTEM_getUserSaveDirectory();
 char *FILESYSTEM_getUserLevelDirectory();
 
-void FILESYSTEM_loadFileToMemory(const char *name, unsigned char **mem, size_t *len);
+bool FILESYSTEM_loadFileToMemory(const char *name, unsigned char **mem, size_t *len);
 void FILESYSTEM_freeMemory(unsigned char **mem);
 
 std::vector<std::string> FILESYSTEM_getLevelDirFileNames();

--- a/include/Game.h
+++ b/include/Game.h
@@ -8,7 +8,6 @@
 #include <UtilityClass.h>
 #include <GraphicsUtil.h>
 
-
 class entityclass;
 class mapclass;
 class Graphics;
@@ -76,13 +75,13 @@ public:
 
     void deletetele();
 
-    void customstart(entityclass& obj, musicclass& music );
+    void customstart();
 
-    void start(entityclass& obj, musicclass& music );
+    void start(musicclass& music );
 
-    void startspecial(int t, entityclass& obj, musicclass& music);
+    void startspecial(int t);
 
-    void starttrial(int t, entityclass& obj, musicclass& music);
+    void starttrial(int t);
 
     void telegotoship()
     {

--- a/include/Graphics.h
+++ b/include/Graphics.h
@@ -121,7 +121,7 @@ public:
 
 	void render();
 
-	bool Hitest(SDL_Surface* surface1, point p1, int col, SDL_Surface* surface2, point p2, int col2);
+	bool Hitest(SDL_Surface* surface1, point p1, SDL_Surface* surface2, point p2);
 
 	void drawentities(mapclass& map, entityclass& obj, UtilityClass& help);
 
@@ -148,12 +148,10 @@ public:
 	void drawbackground(int t, mapclass& map);
 	void drawtile3( int x, int y, int t, int off );
 	void drawentcolours( int x, int y, int t);
-	void drawtile2( int x, int y, int t, int r, int g, int b );
-	void drawtile( int x, int y, int t, int r, int g, int b );
+	void drawtile2( int x, int y, int t );
+	void drawtile( int x, int y, int t);
 	void drawtowertile( int x, int y, int t );
 	void drawtowertile3( int x, int y, int t, int off );
-
-	void drawtile(int x, int y, int t);
 
 	void drawmap(mapclass& map);
 

--- a/include/Input.h
+++ b/include/Input.h
@@ -13,18 +13,16 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game,
                 entityclass& obj, UtilityClass& help, musicclass& music);
 
 void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-               entityclass& obj, UtilityClass& help, musicclass& music);
+               entityclass& obj, musicclass& music);
 
 void mapinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
               entityclass& obj, UtilityClass& help, musicclass& music);
 
 void teleporterinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-                     entityclass& obj, UtilityClass& help, musicclass& music);
+                     entityclass& obj);
 
-void gamecompleteinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-                       entityclass& obj, UtilityClass& help, musicclass& music);
+void gamecompleteinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map);
 
-void gamecompleteinput2(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-                        entityclass& obj, UtilityClass& help, musicclass& music);
+void gamecompleteinput2(KeyPoll& key, Graphics& dwgfx, Game& game, musicclass& music);
 
 #endif /* INPUT_H */

--- a/include/Logic.h
+++ b/include/Logic.h
@@ -8,11 +8,11 @@
 #include <Music.h>
 #include <Map.h>
 
-void titlelogic(Graphics& dwgfx, Game& game, entityclass& obj, UtilityClass& help, musicclass& music, mapclass& map);
+void titlelogic(Game& game, UtilityClass& help, musicclass& music, mapclass& map);
 
-void maplogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help);
+void maplogic(UtilityClass& help);
 
-void gamecompletelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help);
+void gamecompletelogic(Graphics& dwgfx, Game& game, mapclass& map, UtilityClass& help);
 
 void gamecompletelogic2(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help);
 

--- a/include/Map.h
+++ b/include/Map.h
@@ -42,7 +42,7 @@ public:
 
     int maptiletoenemycol(int t);
 
-    void changefinalcol(int t, entityclass& obj, Game& game);
+    void changefinalcol(int t, entityclass& obj);
 
     void setcol(const int r1, const int g1, const int b1 , const int r2, const  int g2, const int b2, const int c);
 
@@ -79,7 +79,7 @@ public:
 
     std::string currentarea(int t);
 
-    void loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclass& obj, musicclass& music);
+    void loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclass& obj);
 
 
     std::vector <int> roomdeaths;

--- a/include/Music.h
+++ b/include/Music.h
@@ -38,7 +38,7 @@ public:
 	// Play a sound effect! There are 16 channels, which iterate
 	void initefchannels();
 
-	void playef(int t, int offset = 0);
+	void playef(int t);
 
 	std::vector<SoundTrack> soundTracks;
 	std::vector<MusicTrack> musicTracks;

--- a/include/Screen.h
+++ b/include/Screen.h
@@ -12,7 +12,6 @@ public:
 	void GetWindowSize(int* x, int* y);
 
 	void UpdateScreen(SDL_Surface* buffer, SDL_Rect* rect);
-	void ClearScreen(int colour);
 	void FlipScreen();
 
 	const SDL_PixelFormat* GetFormat();

--- a/include/Script.h
+++ b/include/Script.h
@@ -34,17 +34,15 @@ public:
     void run(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
              entityclass& obj, UtilityClass& help, musicclass& music);
 
-    void resetgametomenu(Graphics& dwgfx, Game& game,mapclass& map,
-                         entityclass& obj, UtilityClass& help, musicclass& music);
+    void resetgametomenu(Graphics& dwgfx, Game& game, entityclass& obj);
 
-    void startgamemode(int t, KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-                       entityclass& obj, UtilityClass& help, musicclass& music);
+    void startgamemode(int t, Graphics& dwgfx, Game& game, mapclass& map,
+                       entityclass& obj, musicclass& music);
 
     void teleport(Graphics& dwgfx, Game& game, mapclass& map,
-                  entityclass& obj, UtilityClass& help, musicclass& music);
+                  entityclass& obj, musicclass& music);
 
-    void hardreset(KeyPoll& key, Graphics& dwgfx, Game& game,mapclass& map,
-                   entityclass& obj, UtilityClass& help, musicclass& music);
+    void hardreset(Graphics& dwgfx, Game& game,mapclass& map, entityclass& obj);
 
     //Script contents
     std::vector<std::string> commands;

--- a/include/editor.h
+++ b/include/editor.h
@@ -254,7 +254,7 @@ void fillboxabs(Graphics& dwgfx, int x, int y, int x2, int y2, int c);
 
 void editorrender(KeyPoll& key, Graphics& dwgfx, Game& game,  mapclass& map, entityclass& obj, UtilityClass& help);
 
-void editorlogic(KeyPoll& key, Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help);
+void editorlogic(Graphics& dwgfx, Game& game, musicclass& music, mapclass& map, UtilityClass& help);
 
 void editorinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
                  entityclass& obj, UtilityClass& help, musicclass& music);

--- a/include/physfs/physfs.h
+++ b/include/physfs/physfs.h
@@ -124,9 +124,9 @@
  *
  * PhysicsFS is mostly thread safe. The errors returned by
  *  PHYSFS_getLastErrorCode() are unique by thread, and library-state-setting
- *  functions are mutex'd. For efficiency, individual file accesses are 
- *  not locked, so you can not safely read/write/seek/close/etc the same 
- *  file from two threads at the same time. Other race conditions are bugs 
+ *  functions are mutex'd. For efficiency, individual file accesses are
+ *  not locked, so you can not safely read/write/seek/close/etc the same
+ *  file from two threads at the same time. Other race conditions are bugs
  *  that should be reported/patched.
  *
  * While you CAN use stdio/syscall file access in a program that has PHYSFS_*

--- a/include/titlerender.h
+++ b/include/titlerender.h
@@ -18,7 +18,9 @@ extern Stage stage;
 extern Stage swfStage;
 extern int temp;
 
-void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, UtilityClass& help, musicclass& music);
+void updategraphicsmode();
+
+void titlerender(Graphics& dwgfx, mapclass& map, Game& game, UtilityClass& help, musicclass& music);
 
 void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help);
 
@@ -28,8 +30,8 @@ void maprender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, Uti
 
 void teleporterrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help);
 
-void gamecompleterender(Graphics& dwgfx, Game& game, entityclass& obj, UtilityClass& help, mapclass& map);
+void gamecompleterender(Graphics& dwgfx, Game& game, UtilityClass& help, mapclass& map);
 
-void gamecompleterender2(Graphics& dwgfx, Game& game, entityclass& obj, UtilityClass& help);
+void gamecompleterender2(Graphics& dwgfx, Game& game);
 
 #endif /* TITLERENDERER_H */

--- a/makefile
+++ b/makefile
@@ -18,7 +18,7 @@ CPP_DEPS = $(patsubst src/%.cpp, build/%.d, ${CPP_SRCS})
 BINARY_NAME = vvvvvv
 BINARY_PATH = bin/${BINARY_NAME}
 
-ASSET_DOWNLOAD_FILE = VVVVVV-MP-10202016.zip
+ASSET_DOWNLOAD_FILE = vvvvvv-mp-11192019-bin
 ASSET_DOWNLOAD_URL = http://www.flibitijibibo.com/${ASSET_DOWNLOAD_FILE}
 ASSET_FILE_NAME = data.zip
 
@@ -54,11 +54,11 @@ build/%.o: src/%.cpp
 build/%.o: src/%.c
 	${C_COMPILER} ${C_CFLAGS} -MMD -c $< -o $@
 
-bin/${ASSET_FILE_NAME}: build/${ASSET_FILE_NAME}
-	cp -v build/${ASSET_FILE_NAME} $@
+bin/${ASSET_FILE_NAME}: build/data/${ASSET_FILE_NAME}
+	cp $< $@
 
-build/${ASSET_FILE_NAME}: build/${ASSET_DOWNLOAD_FILE}
-	unzip -p build/${ASSET_DOWNLOAD_FILE} build/VVVVVV-MP/${ASSET_FILE_NAME} > $@
+build/data/${ASSET_FILE_NAME}: build/${ASSET_DOWNLOAD_FILE}
+	-unzip -u -d build/ build/${ASSET_DOWNLOAD_FILE}
 
 build/${ASSET_DOWNLOAD_FILE}:
 	wget ${ASSET_DOWNLOAD_URL} -O $@

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 # Used to compile VVVVVV and tinyxml
 CPP_COMPILER = g++
-CPP_CFLAGS = -std=c++14 -MMD -Iinclude/
-CPP_LFLAGS = -lSDL2 -lSDL2_mixer
+CPP_CFLAGS = -std=c++17 -Wall -MMD -Iinclude/
+CPP_LFLAGS = -Wall -lSDL2 -lSDL2_mixer
 
 # Used to compile physfs and lodepng
 C_COMPILER = gcc

--- a/makefile
+++ b/makefile
@@ -18,10 +18,14 @@ CPP_DEPS = $(patsubst src/%.cpp, build/%.d, ${CPP_SRCS})
 BINARY_NAME = vvvvvv
 BINARY_PATH = bin/${BINARY_NAME}
 
-all: ${BINARY_PATH}
+ASSET_DOWNLOAD_FILE = VVVVVV-MP-10202016.zip
+ASSET_DOWNLOAD_URL = http://www.flibitijibibo.com/${ASSET_DOWNLOAD_FILE}
+ASSET_FILE_NAME = data.zip
+
+all: ${BINARY_PATH} bin/${ASSET_FILE_NAME}
 
 clean:
-	-rm -rf build/ ${BINARY_PATH}
+	-rm -rf ${CPP_OBJS} ${C_OBJS} ${CPP_DEPS} ${C_DEPS} ${BINARY_PATH}
 
 check: all
 	cd bin/ && ./${BINARY_NAME}
@@ -41,7 +45,7 @@ debug:
 
 .PHONY: all clean check directories debug
 
-${BINARY_PATH}: directories ${CPP_OBJS} ${C_OBJS}
+${BINARY_PATH}: directories  ${CPP_OBJS} ${C_OBJS}
 	${CPP_COMPILER} ${C_OBJS} ${CPP_OBJS} ${CPP_LFLAGS} -o $@
 
 build/%.o: src/%.cpp
@@ -49,6 +53,15 @@ build/%.o: src/%.cpp
 
 build/%.o: src/%.c
 	${C_COMPILER} ${C_CFLAGS} -MMD -c $< -o $@
+
+bin/${ASSET_FILE_NAME}: build/${ASSET_FILE_NAME}
+	cp -v build/${ASSET_FILE_NAME} $@
+
+build/${ASSET_FILE_NAME}: build/${ASSET_DOWNLOAD_FILE}
+	unzip -p build/${ASSET_DOWNLOAD_FILE} build/VVVVVV-MP/${ASSET_FILE_NAME} > $@
+
+build/${ASSET_DOWNLOAD_FILE}:
+	wget ${ASSET_DOWNLOAD_URL} -O $@
 
 -include ${CPP_DEPS}
 

--- a/makefile
+++ b/makefile
@@ -1,11 +1,11 @@
 # Used to compile VVVVVV and tinyxml
 CPP_COMPILER = g++
-CPP_CFLAGS = -std=c++17 -Wall -MMD -Iinclude/
+CPP_CFLAGS = -std=c++17 -Wall -Wextra -Iinclude/
 CPP_LFLAGS = -Wall -lSDL2 -lSDL2_mixer
 
 # Used to compile physfs and lodepng
 C_COMPILER = gcc
-C_CFLAGS = -MMD -Iinclude/
+C_CFLAGS = -Iinclude/
 
 C_SRCS = $(shell find src/ -name '*.c')
 C_OBJS = $(patsubst src/%.c, build/%.o, ${C_SRCS})
@@ -26,6 +26,9 @@ clean:
 check: all
 	cd bin/ && ./${BINARY_NAME}
 
+check-syntax:
+	${CPP_COMPILER} ${C_CFLAGS} -fsyntax-only ${CPP_SRCS}
+
 directories:
 	mkdir -p bin/ build/lodepng build/physfs build/src build/tinyxml
 
@@ -42,10 +45,10 @@ ${BINARY_PATH}: directories ${CPP_OBJS} ${C_OBJS}
 	${CPP_COMPILER} ${C_OBJS} ${CPP_OBJS} ${CPP_LFLAGS} -o $@
 
 build/%.o: src/%.cpp
-	${CPP_COMPILER} ${CPP_CFLAGS} -c $< -o $@
+	${CPP_COMPILER} ${CPP_CFLAGS} -MMD -c $< -o $@
 
 build/%.o: src/%.c
-	${C_COMPILER} ${C_CFLAGS} -c $< -o $@
+	${C_COMPILER} ${C_CFLAGS} -MMD -c $< -o $@
 
 -include ${CPP_DEPS}
 

--- a/src/BinaryBlob.cpp
+++ b/src/BinaryBlob.cpp
@@ -91,7 +91,7 @@ bool binaryBlob::unPackBinary(const char* name)
 
 	size = PHYSFS_fileLength(handle);
 
-	PHYSFS_read(handle, &m_headers, 1, sizeof(resourceheader) * 128);
+	PHYSFS_readBytes(handle, &m_headers, sizeof(resourceheader) * 128);
 
 	int offset = 0 + (sizeof(resourceheader) * 128);
 
@@ -101,7 +101,7 @@ bool binaryBlob::unPackBinary(const char* name)
 		{
 			PHYSFS_seek(handle, offset);
 			m_memblocks[i] = (char*) malloc(m_headers[i].size);
-			PHYSFS_read(handle, m_memblocks[i], 1, m_headers[i].size);
+			PHYSFS_readBytes(handle, m_memblocks[i], m_headers[i].size);
 			offset += m_headers[i].size;
 		}
 	}

--- a/src/BinaryBlob.cpp
+++ b/src/BinaryBlob.cpp
@@ -107,7 +107,7 @@ bool binaryBlob::unPackBinary(const char* name)
 	}
 	PHYSFS_close(handle);
 
-	printf("The complete reloaded file size: %li\n", size);
+	printf("The complete reloaded file size: %lli\n", size);
 
 	for (int i = 0; i < 128; i += 1)
 	{

--- a/src/Entity.cpp
+++ b/src/Entity.cpp
@@ -242,7 +242,7 @@ void entityclass::gravcreate( Game& game, int ypos, int dir, int xoff /*= 0*/, i
     }
 }
 
-void entityclass::generateswnwave( Game& game, UtilityClass& help, int t )
+void entityclass::generateswnwave( Game& game, int t )
 {
     //generate a wave for the SWN game
     if(game.swndelay<=0)
@@ -3132,7 +3132,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                     entities[i].state = 2;
                     entities[i].onentity = 0;
 
-                    music.playef(7,10);
+                    music.playef(7);
                 }
                 else if (entities[i].state == 2)
                 {
@@ -3180,7 +3180,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                     entities[i].life = 4;
                     entities[i].state = 2;
                     entities[i].onentity = 0;
-                    music.playef(6,10);
+                    music.playef(6);
                     /*}else if (entities[j].vy <= -0.5  && (entities[j].yp>=entities[i].yp+2)) {
                     entities[i].life = 4;
                     entities[i].state = 2; entities[i].onentity = 0;
@@ -3220,7 +3220,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                 if (entities[i].state == 1)
                 {
                     game.coins++;
-                    music.playef(4,10);
+                    music.playef(4);
                     collect[entities[i].para] = 1;
 
                     entities[i].active = false;
@@ -3234,14 +3234,14 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                     if (game.intimetrial)
                     {
                         collect[entities[i].para] = 1;
-                        music.playef(25,10);
+                        music.playef(25);
                     }
                     else
                     {
                         game.state = 1000;
                         //music.haltdasmusik();
                         if(music.currentsong!=-1) music.silencedasmusik();
-                        music.playef(3,10);
+                        music.playef(3);
                         collect[entities[i].para] = 1;
                         if (game.trinkets > game.stat_trinkets)
                         {
@@ -3268,7 +3268,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                     entities[i].colour = 5;
                     entities[i].onentity = 0;
                     game.savepoint = entities[i].para;
-                    music.playef(5,10);
+                    music.playef(5);
 
                     game.savex = entities[i].xp - 4;
 
@@ -3309,7 +3309,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                     entities[i].state = 2;
 
 
-                    music.playef(8,10);
+                    music.playef(8);
                     game.gravitycontrol = (game.gravitycontrol + 1) % 2;
                     game.totalflips++;
                     temp = getplayer();
@@ -3688,7 +3688,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                 {
                     entities[i].colour = 5;
                     entities[i].onentity = 0;
-                    music.playef(17,10);
+                    music.playef(17);
 
                     entities[i].state = 0;
                 }
@@ -3856,14 +3856,14 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                     if (game.intimetrial)
                     {
                         customcollect[entities[i].para] = 1;
-                        music.playef(27,10);
+                        music.playef(27);
                     }
                     else
                     {
                         game.state = 1010;
                         //music.haltdasmusik();
                         if(music.currentsong!=-1) music.silencedasmusik();
-                        music.playef(27,10);
+                        music.playef(27);
                         customcollect[entities[i].para] = 1;
                     }
 
@@ -3876,7 +3876,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
                     //if inactive, activate!
                     if (entities[i].tile == 1)
                     {
-                        music.playef(18, 10);
+                        music.playef(18);
                         entities[i].onentity = 0;
                         entities[i].tile = 2;
                         entities[i].colour = 101;
@@ -3947,7 +3947,7 @@ bool entityclass::updateentities( int i, UtilityClass& help, Game& game, musiccl
     return true;
 }
 
-void entityclass::animateentities( int _i, Game& game, UtilityClass& help )
+void entityclass::animateentities( int _i, Game& game )
 {
     if(entities[_i].active)
     {
@@ -4325,7 +4325,7 @@ bool entityclass::gettype( int t )
     return false;
 }
 
-int entityclass::getcompanion( int t )
+int entityclass::getcompanion()
 {
     //Returns the index of the companion with rule t
     for (int i = 0; i < nentity; i++)
@@ -4480,7 +4480,7 @@ bool entityclass::entitycollide( int a, int b )
     return false;
 }
 
-bool entityclass::checkdirectional( int t )
+bool entityclass::checkdirectional()
 {
     //Returns true if player entity (rule 0) moving in dir t through directional block
     for(int i=0; i < nentity; i++)
@@ -4848,7 +4848,7 @@ bool entityclass::entitywarphlinecollide(int t, int l) {
 					if (entities[t].oldyp < entities[l].yp + 10) linetemp++;
 					if (entities[t].oldyp + entities[t].h < entities[l].yp + 10) linetemp++;
 				}
-							
+
 				if (linetemp > 0) return true;
 				return false;
 			}else {
@@ -4859,7 +4859,7 @@ bool entityclass::entitywarphlinecollide(int t, int l) {
 					if (entities[t].oldyp > entities[l].yp - 10) linetemp++;
 					if (entities[t].oldyp + entities[t].h > entities[l].yp - 10) linetemp++;
 				}
-						
+
 				if (linetemp > 0) return true;
 				return false;
 			}
@@ -4867,7 +4867,7 @@ bool entityclass::entitywarphlinecollide(int t, int l) {
 	}
 	return false;
 }
-		
+
 bool entityclass::entitywarpvlinecollide(int t, int l) {
 	//Returns true is entity t collided with the vertical warp line l.
 	if(entities[t].yp + entities[t].cy+entities[t].h>=entities[l].yp){
@@ -4879,7 +4879,7 @@ bool entityclass::entitywarpvlinecollide(int t, int l) {
 				if (entities[t].xp + entities[t].cx+1 + entities[t].w < entities[l].xp + 10) linetemp++;
 				if (entities[t].oldxp + entities[t].cx + 1 < entities[l].xp + 10) linetemp++;
 				if (entities[t].oldxp + entities[t].cx + 1 + entities[t].w < entities[l].xp + 10) linetemp++;
-						
+
 				if (linetemp > 0) return true;
 				return false;
 			}else {
@@ -4888,7 +4888,7 @@ bool entityclass::entitywarpvlinecollide(int t, int l) {
 				if (entities[t].xp + entities[t].cx+1 + entities[t].w > entities[l].xp - 10) linetemp++;
 				if (entities[t].oldxp + entities[t].cx + 1 > entities[l].xp - 10) linetemp++;
 				if (entities[t].oldxp + entities[t].cx + 1 + entities[t].w > entities[l].xp - 10) linetemp++;
-						
+
 				if (linetemp > 0) return true;
 				return false;
 			}
@@ -4897,7 +4897,7 @@ bool entityclass::entitywarpvlinecollide(int t, int l) {
 	return false;
 }
 
-float entityclass::entitycollideplatformroof( mapclass& map, int t )
+float entityclass::entitycollideplatformroof( int t )
 {
     tempx = entities[t].xp + entities[t].cx;
     tempy = entities[t].yp + entities[t].cy -1;
@@ -4913,7 +4913,7 @@ float entityclass::entitycollideplatformroof( mapclass& map, int t )
     return -1000;
 }
 
-float entityclass::entitycollideplatformfloor( mapclass& map, int t )
+float entityclass::entitycollideplatformfloor( int t )
 {
     tempx = entities[t].xp + entities[t].cx;
     tempy = entities[t].yp + entities[t].cy + 1;
@@ -5220,7 +5220,7 @@ void entityclass::scmmovingplatformfix( int t, mapclass& map )
     }
 }
 
-void entityclass::hormovingplatformfix( int t, mapclass& map )
+void entityclass::hormovingplatformfix(int t)
 {
     //If this intersects the player, then we move the player along it
     //for horizontal platforms, this is simplier
@@ -5238,21 +5238,21 @@ void entityclass::hormovingplatformfix( int t, mapclass& map )
 void entityclass::customwarplinecheck(int i) {
 		//Turns on obj.customwarpmodevon and obj.customwarpmodehon if player collides
 		//with warp lines
-			
+
 	if (entities[i].active) {
 		//We test entity to entity
 		for (int j = 0; j < nentity; j++) {
 			if (entities[j].active && i != j) {//Active
 				if (entities[i].rule == 0 && entities[j].rule == 5) { //Player vs vertical line!
-					if (entities[j].type == 51 || entities[j].type == 52) {								
-						if (entitywarpvlinecollide(i, j)) {	
+					if (entities[j].type == 51 || entities[j].type == 52) {
+						if (entitywarpvlinecollide(i, j)) {
 							customwarpmodevon = true;
 						}
 					}
 				}
-						
+
 				if (entities[i].rule == 0 && entities[j].rule == 7){   //Player vs horizontal WARP line
-					if (entities[j].type == 53 || entities[j].type == 54) {								
+					if (entities[j].type == 53 || entities[j].type == 54) {
 						if (entitywarphlinecollide(i, j)) {
 							customwarpmodehon = true;
 						}
@@ -5289,7 +5289,7 @@ void entityclass::entitycollisioncheck( Graphics& dwgfx, Game& game, mapclass& m
                                 if (dwgfx.flipmode)
                                 {
                                     if (dwgfx.Hitest(dwgfx.flipsprites[entities[i].drawframe],
-                                                     colpoint1, 1, dwgfx.flipsprites[entities[j].drawframe], colpoint2, 1))
+                                                     colpoint1, dwgfx.flipsprites[entities[j].drawframe], colpoint2))
                                     {
                                         //Do the collision stuff
                                         game.deathseq = 30;
@@ -5298,7 +5298,7 @@ void entityclass::entitycollisioncheck( Graphics& dwgfx, Game& game, mapclass& m
                                 else
                                 {
                                     if (dwgfx.Hitest(dwgfx.sprites[entities[i].drawframe],
-                                                     colpoint1, 1, dwgfx.sprites[entities[j].drawframe], colpoint2, 1) )
+                                                     colpoint1, dwgfx.sprites[entities[j].drawframe], colpoint2) )
                                     {
                                         //Do the collision stuff
                                         game.deathseq = 30;
@@ -5333,7 +5333,7 @@ void entityclass::entitycollisioncheck( Graphics& dwgfx, Game& game, mapclass& m
                             {
                                 if (entityhlinecollide(i, j))
                                 {
-                                    music.playef(8,10);
+                                    music.playef(8);
                                     game.gravitycontrol = (game.gravitycontrol + 1) % 2;
                                     game.totalflips++;
                                     if (game.gravitycontrol == 0)
@@ -5417,7 +5417,7 @@ void entityclass::entitycollisioncheck( Graphics& dwgfx, Game& game, mapclass& m
                                         if (dwgfx.flipmode)
                                         {
                                             if (dwgfx.Hitest(dwgfx.flipsprites[entities[i].drawframe],
-                                                             colpoint1, 1, dwgfx.flipsprites[entities[j].drawframe], colpoint2, 1))
+                                                             colpoint1, dwgfx.flipsprites[entities[j].drawframe], colpoint2))
                                             {
                                                 //Do the collision stuff
                                                 game.deathseq = 30;
@@ -5427,7 +5427,7 @@ void entityclass::entitycollisioncheck( Graphics& dwgfx, Game& game, mapclass& m
                                         else
                                         {
                                             if (dwgfx.Hitest(dwgfx.sprites[entities[i].drawframe],
-                                                             colpoint1, 1, dwgfx.sprites[entities[j].drawframe], colpoint2, 1))
+                                                             colpoint1, dwgfx.sprites[entities[j].drawframe], colpoint2))
                                             {
                                                 //Do the collision stuff
                                                 game.deathseq = 30;

--- a/src/FileSystemUtils.cpp
+++ b/src/FileSystemUtils.cpp
@@ -141,21 +141,8 @@ std::vector<std::string> FILESYSTEM_getLevelDirFileNames()
 
 void PLATFORM_getOSDirectory(char* output)
 {
-#if defined(__linux__)
-	const char *homeDir = getenv("XDG_DATA_HOME");
-	if (homeDir == NULL)
-	{
-		strcpy(output, PHYSFS_getUserDir());
-		strcat(output, ".local/share/VVVVVV/");
-	}
-	else
-	{
-		strcpy(output, homeDir);
-		strcat(output, "/VVVVVV/");
-	}
-#elif defined(__APPLE__)
-	strcpy(output, PHYSFS_getUserDir());
-	strcat(output, "Library/Application Support/VVVVVV/");
+#if defined(__linux__) || defined(__APPLE__)
+	strcpy(output, PHYSFS_getPrefDir("distractionware", "VVVVVV"));
 #elif defined(_WIN32)
 	SHGetFolderPath(NULL, CSIDL_PERSONAL, NULL, SHGFP_TYPE_CURRENT, output);
 	strcat(output, "\\VVVVVV\\");

--- a/src/FileSystemUtils.cpp
+++ b/src/FileSystemUtils.cpp
@@ -106,7 +106,7 @@ void FILESYSTEM_loadFileToMemory(const char *name, unsigned char **mem, size_t *
 		*len = length;
 	}
 	*mem = (unsigned char*) malloc(length);
-	PHYSFS_read(handle, *mem, 1, length);
+	PHYSFS_readBytes(handle, *mem, length);
 	PHYSFS_close(handle);
 }
 

--- a/src/FileSystemUtils.cpp
+++ b/src/FileSystemUtils.cpp
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include <physfs/physfs.h>
+#include <stdexcept>
 
 #if defined(_WIN32)
 #include <windows.h>
@@ -36,7 +37,11 @@ void FILESYSTEM_init(char *argvZero)
 	char output[MAX_PATH];
 	int mkdirResult;
 
-	PHYSFS_init(argvZero);
+	if (PHYSFS_init(argvZero) == 0)
+	{
+		std::printf("FILESYSTEM_init: Error %i when initializing PhysFS\n", PHYSFS_getLastErrorCode());
+		throw std::runtime_error("Failed to initialize PhysFS, aborting");
+	}
 
 	/* Determine the OS user directory */
 	PLATFORM_getOSDirectory(output);
@@ -45,22 +50,26 @@ void FILESYSTEM_init(char *argvZero)
 	mkdirResult = mkdir(output, 0777);
 
 	/* Mount our base user directory */
-	PHYSFS_mount(output, NULL, 1);
-	printf("Base directory: %s\n", output);
+	if (PHYSFS_mount(output, NULL, 1) == 0)
+	{
+		std::printf("FILESYSTEM_init: Error %i when mounting base user directory %s\n", PHYSFS_getLastErrorCode(), output);
+		throw std::runtime_error("Failed to mount base user directory, aborting");
+	}
+	printf("FILESYSTEM_init: Base directory: %s\n", output);
 
 	/* Create save directory */
 	strcpy(saveDir, output);
 	strcat(saveDir, "saves");
 	strcat(saveDir, PHYSFS_getDirSeparator());
 	mkdir(saveDir, 0777);
-	printf("Save directory: %s\n", saveDir);
+	printf("FILESYSTEM_init: Save directory: %s\n", saveDir);
 
 	/* Create level directory */
 	strcpy(levelDir, output);
 	strcat(levelDir, "levels");
 	strcat(levelDir, PHYSFS_getDirSeparator());
 	mkdirResult |= mkdir(levelDir, 0777);
-	printf("Level directory: %s\n", levelDir);
+	printf("FILESYSTEM_init: Level directory: %s\n", levelDir);
 
 	/* We didn't exist until now, migrate files! */
 	if (VNEEDS_MIGRATION)
@@ -75,7 +84,12 @@ void FILESYSTEM_init(char *argvZero)
 #else
 	strcpy(output, "data.zip");
 #endif
-	PHYSFS_mount(output, NULL, 1);
+	std::printf("FILESYSTEM_init: Loading stock content from %s\n", output);
+	if (PHYSFS_mount(output, NULL, 1) == 0)
+	{
+		std::printf("FILESYSTEM_init: Error %i mounting PhysFS on %s\n", PHYSFS_getLastErrorCode(), output);
+		throw std::runtime_error("Failed to mount PhysFS, aborting");
+	}
 }
 
 void FILESYSTEM_deinit()
@@ -93,21 +107,29 @@ char *FILESYSTEM_getUserLevelDirectory()
 	return levelDir;
 }
 
-void FILESYSTEM_loadFileToMemory(const char *name, unsigned char **mem, size_t *len)
+bool FILESYSTEM_loadFileToMemory(const char *name, unsigned char **mem, size_t *len)
 {
 	PHYSFS_File *handle = PHYSFS_openRead(name);
 	if (handle == NULL)
 	{
-		return;
+		std::printf("FILESYSTEM_loadFileToMemory: Error <%i> when loading <%s>\n", PHYSFS_getLastErrorCode(), name);
+		return false;
 	}
+
 	PHYSFS_uint32 length = PHYSFS_fileLength(handle);
 	if (len != NULL)
 	{
 		*len = length;
 	}
 	*mem = (unsigned char*) malloc(length);
-	PHYSFS_readBytes(handle, *mem, length);
+	if (PHYSFS_readBytes(handle, *mem, length) < 0)
+	{
+		std::printf("FILESYSTEM_loadFileToMemory: Error <%i> reading bytes from <%s>\n", PHYSFS_getLastErrorCode(), name);
+		return false;
+	}
+
 	PHYSFS_close(handle);
+	return true;
 }
 
 void FILESYSTEM_freeMemory(unsigned char **mem)

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -832,7 +832,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             if(obj.entities[obj.getplayer()].tile == 0)
             {
                 obj.entities[obj.getplayer()].tile = 144;
-                music.playef(2, 10);
+                music.playef(2);
             }
             state = 0;
             break;
@@ -1210,7 +1210,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             break;
 
         case 50:
-            music.playef(15, 10);
+            music.playef(15);
             dwgfx.createtextbox("Help! Can anyone hear", 35, 15, 255, 134, 255);
             dwgfx.addline("this message?");
             dwgfx.textboxtimer(60);
@@ -1218,7 +1218,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 100;
             break;
         case 51:
-            music.playef(15, 10);
+            music.playef(15);
             dwgfx.createtextbox("Verdigris? Are you out", 30, 12, 255, 134, 255);
             dwgfx.addline("there? Are you ok?");
             dwgfx.textboxtimer(60);
@@ -1226,7 +1226,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 100;
             break;
         case 52:
-            music.playef(15, 10);
+            music.playef(15);
             dwgfx.createtextbox("Please help us! We've crashed", 5, 22, 255, 134, 255);
             dwgfx.addline("and need assistance!");
             dwgfx.textboxtimer(60);
@@ -1234,14 +1234,14 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 100;
             break;
         case 53:
-            music.playef(15, 10);
+            music.playef(15);
             dwgfx.createtextbox("Hello? Anyone out there?", 40, 15, 255, 134, 255);
             dwgfx.textboxtimer(60);
             state++;
             statedelay = 100;
             break;
         case 54:
-            music.playef(15, 10);
+            music.playef(15);
             dwgfx.createtextbox("This is Doctor Violet from the", 5, 8, 255, 134, 255);
             dwgfx.addline("D.S.S. Souleye! Please respond!");
             dwgfx.textboxtimer(60);
@@ -1249,14 +1249,14 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 100;
             break;
         case 55:
-            music.playef(15, 10);
+            music.playef(15);
             dwgfx.createtextbox("Please... Anyone...", 45, 14, 255, 134, 255);
             dwgfx.textboxtimer(60);
             state++;
             statedelay = 100;
             break;
         case 56:
-            music.playef(15, 10);
+            music.playef(15);
             dwgfx.createtextbox("Please be alright, everyone...", 25, 18, 255, 134, 255);
             dwgfx.textboxtimer(60);
             state=50;
@@ -1340,7 +1340,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             obj.removetrigger(85);
             //Init final stretch
             state++;
-            music.playef(9, 10);
+            music.playef(9);
             music.play(2);
             obj.flags[72] = 1;
 
@@ -1433,7 +1433,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             if (obj.entities[i].onroof > 0 && gravitycontrol == 1)
             {
                 gravitycontrol = 0;
-                music.playef(1, 10);
+                music.playef(1);
             }
             if (obj.entities[i].onground > 0)
             {
@@ -1446,7 +1446,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
 
             companion = 6;
-            i = obj.getcompanion(6);
+            i = obj.getcompanion();
             obj.entities[i].tile = 0;
             obj.entities[i].state = 1;
 
@@ -1455,13 +1455,13 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
             dwgfx.createtextbox("Captain! I've been so worried!", 60, 90, 164, 255, 164);
             state++;
-            music.playef(12, 10);
+            music.playef(12);
         }
         break;
         case 104:
             dwgfx.createtextbox("I'm glad you're ok!", 135, 152, 164, 164, 255);
             state++;
-            music.playef(11, 10);
+            music.playef(11);
             dwgfx.textboxactive();
             break;
         case 106:
@@ -1470,9 +1470,9 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             dwgfx.addline("way out, but I keep going");
             dwgfx.addline("around in circles...");
             state++;
-            music.playef(2, 10);
+            music.playef(2);
             dwgfx.textboxactive();
-            i = obj.getcompanion(6);
+            i = obj.getcompanion();
             obj.entities[i].tile = 54;
             obj.entities[i].state = 0;
         }
@@ -1481,18 +1481,18 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             dwgfx.createtextbox("Don't worry! I have a", 125, 152, 164, 164, 255);
             dwgfx.addline("teleporter key!");
             state++;
-            music.playef(11, 10);
+            music.playef(11);
             dwgfx.textboxactive();
             break;
         case 110:
         {
 
-            i = obj.getcompanion(6);
+            i = obj.getcompanion();
             obj.entities[i].tile = 0;
             obj.entities[i].state = 1;
             dwgfx.createtextbox("Follow me!", 185, 154, 164, 164, 255);
             state++;
-            music.playef(11, 10);
+            music.playef(11);
             dwgfx.textboxactive();
 
         }
@@ -1551,7 +1551,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             if (obj.entities[i].onground > 0 && gravitycontrol == 0)
             {
                 gravitycontrol = 1;
-                music.playef(1, 10);
+                music.playef(1);
             }
             if (obj.entities[i].onroof > 0)
             {
@@ -1562,7 +1562,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
         break;
         case 122:
             companion = 7;
-            i = obj.getcompanion(7);
+            i = obj.getcompanion();
             obj.entities[i].tile = 6;
             obj.entities[i].state = 1;
 
@@ -1571,36 +1571,36 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
 
             dwgfx.createtextbox("Captain! You're ok!", 60-10, 90-40, 255, 255, 134);
             state++;
-            music.playef(14, 10);
+            music.playef(14);
             break;
         case 124:
             dwgfx.createtextbox("I've found a teleporter, but", 60-20, 90 - 40, 255, 255, 134);
             dwgfx.addline("I can't get it to go anywhere...");
             state++;
-            music.playef(2, 10);
+            music.playef(2);
             dwgfx.textboxactive();
-            i = obj.getcompanion(7);	//obj.entities[i].tile = 66;	obj.entities[i].state = 0;
+            i = obj.getcompanion();	//obj.entities[i].tile = 66;	obj.entities[i].state = 0;
             break;
         case 126:
             dwgfx.createtextbox("I can help with that!", 125, 152-40, 164, 164, 255);
             state++;
-            music.playef(11, 10);
+            music.playef(11);
             dwgfx.textboxactive();
             break;
         case 128:
             dwgfx.createtextbox("I have the teleporter", 130, 152-35, 164, 164, 255);
             dwgfx.addline("codex for our ship!");
             state++;
-            music.playef(11, 10);
+            music.playef(11);
             dwgfx.textboxactive();
             break;
 
         case 130:
             dwgfx.createtextbox("Yey! Let's go home!", 60-30, 90-35, 255, 255, 134);
             state++;
-            music.playef(14, 10);
+            music.playef(14);
             dwgfx.textboxactive();
-            i = obj.getcompanion(7);
+            i = obj.getcompanion();
             obj.entities[i].tile = 6;
             obj.entities[i].state = 1;
             break;
@@ -1615,7 +1615,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
         case 200:
             //Init final stretch
             state++;
-            music.playef(9, 10);
+            music.playef(9);
             //music.play(2);
             obj.flags[72] = 1;
 
@@ -2063,7 +2063,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 15;
             flashlight = 5;
             screenshake = 90;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 2501:
             //Activating a teleporter 2
@@ -2072,7 +2072,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             flashlight = 5;
             screenshake = 0;
             //we're done here!
-            music.playef(10, 10);
+            music.playef(10);
             break;
         case 2502:
             //Activating a teleporter 2
@@ -2135,7 +2135,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             hascontrol = false;
             dwgfx.createtextbox("Hello?", 125+24, 152-20, 164, 164, 255);
             state++;
-            music.playef(11, 10);
+            music.playef(11);
             dwgfx.textboxactive();
             break;
         case 2512:
@@ -2143,7 +2143,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             hascontrol = false;
             dwgfx.createtextbox("Is anyone there?", 125+8, 152-24, 164, 164, 255);
             state++;
-            music.playef(11, 10);
+            music.playef(11);
             dwgfx.textboxactive();
             break;
         case 2514:
@@ -2162,28 +2162,28 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 30;
             flashlight = 5;
             screenshake = 90;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 3001:
             //Activating a teleporter 2
             state++;
             statedelay = 15;
             flashlight = 5;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 3002:
             //Activating a teleporter 2
             state++;
             statedelay = 15;
             flashlight = 5;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 3003:
             //Activating a teleporter 2
             state++;
             statedelay = 15;
             flashlight = 5;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 3004:
             //Activating a teleporter 2
@@ -2192,7 +2192,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             flashlight = 5;
             screenshake = 0;
             //we're done here!
-            music.playef(10, 10);
+            music.playef(10);
             break;
         case 3005:
             //Activating a teleporter 2
@@ -2227,7 +2227,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             obj.entities[i].colour = 0;
             obj.entities[i].invis = true;
 
-            i = obj.getcompanion(companion);
+            i = obj.getcompanion();
             if(i>-1)
             {
                 obj.entities[i].active = false;
@@ -3206,28 +3206,28 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 30;
             flashlight = 5;
             screenshake = 90;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 3512:
             //Activating a teleporter 2
             state++;
             statedelay = 15;
             flashlight = 5;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 3513:
             //Activating a teleporter 2
             state++;
             statedelay = 15;
             flashlight = 5;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 3514:
             //Activating a teleporter 2
             state++;
             statedelay = 15;
             flashlight = 5;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 3515:
             //Activating a teleporter 2
@@ -3241,7 +3241,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             obj.entities[i].invis = true;
 
             //we're done here!
-            music.playef(10, 10);
+            music.playef(10);
             statedelay = 60;
             break;
         case 3516:
@@ -3303,7 +3303,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 10;
             flashlight = 5;
             screenshake = 10;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 4001:
             //Activating a teleporter 2
@@ -3312,7 +3312,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             flashlight = 5;
             screenshake = 0;
             //we're done here!
-            music.playef(10, 10);
+            music.playef(10);
             break;
         case 4002:
             //Activating a teleporter 2
@@ -3346,7 +3346,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 15;
             flashlight = 5;
             screenshake = 90;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 4011:
             //Activating a teleporter 2
@@ -3354,7 +3354,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 0;
             flashlight = 5;
             screenshake = 0;
-            music.playef(10, 10);
+            music.playef(10);
             break;
         case 4012:
             //Activating a teleporter 2
@@ -3435,7 +3435,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 15;
             flashlight = 5;
             screenshake = 90;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 4021:
             //Activating a teleporter 2
@@ -3443,7 +3443,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 0;
             flashlight = 5;
             screenshake = 0;
-            music.playef(10, 10);
+            music.playef(10);
             break;
         case 4022:
             //Activating a teleporter 2
@@ -3511,7 +3511,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 15;
             flashlight = 5;
             screenshake = 90;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 4031:
             //Activating a teleporter 2
@@ -3519,7 +3519,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 0;
             flashlight = 5;
             screenshake = 0;
-            music.playef(10, 10);
+            music.playef(10);
             break;
         case 4032:
             //Activating a teleporter 2
@@ -3587,7 +3587,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 15;
             flashlight = 5;
             screenshake = 90;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 4041:
             //Activating a teleporter 2
@@ -3595,7 +3595,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 0;
             flashlight = 5;
             screenshake = 0;
-            music.playef(10, 10);
+            music.playef(10);
             break;
         case 4042:
             //Activating a teleporter 2
@@ -3668,7 +3668,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 15;
             flashlight = 5;
             screenshake = 90;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 4051:
             //Activating a teleporter 2
@@ -3676,7 +3676,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 0;
             flashlight = 5;
             screenshake = 0;
-            music.playef(10, 10);
+            music.playef(10);
             break;
         case 4052:
             //Activating a teleporter 2
@@ -3749,7 +3749,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 15;
             flashlight = 5;
             screenshake = 90;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 4061:
             //Activating a teleporter 2
@@ -3757,7 +3757,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 0;
             flashlight = 5;
             screenshake = 0;
-            music.playef(10, 10);
+            music.playef(10);
             break;
         case 4062:
             //Activating a teleporter 2
@@ -3828,7 +3828,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 15;
             flashlight = 5;
             screenshake = 90;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 4071:
             //Activating a teleporter 2
@@ -3836,7 +3836,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 0;
             flashlight = 5;
             screenshake = 0;
-            music.playef(10, 10);
+            music.playef(10);
             break;
         case 4072:
             //Activating a teleporter 2
@@ -3904,7 +3904,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 15;
             flashlight = 5;
             screenshake = 90;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 4081:
             //Activating a teleporter 2
@@ -3912,7 +3912,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 0;
             flashlight = 5;
             screenshake = 0;
-            music.playef(10, 10);
+            music.playef(10);
             break;
         case 4082:
             //Activating a teleporter 2
@@ -3980,7 +3980,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 15;
             flashlight = 5;
             screenshake = 90;
-            music.playef(9, 10);
+            music.playef(9);
             break;
         case 4091:
             //Activating a teleporter 2
@@ -3988,7 +3988,7 @@ void Game::updatestate( Graphics& dwgfx, mapclass& map, entityclass& obj, Utilit
             statedelay = 0;
             flashlight = 5;
             screenshake = 0;
-            music.playef(10, 10);
+            music.playef(10);
             break;
         case 4092:
             //Activating a teleporter 2
@@ -4583,7 +4583,7 @@ void Game::savestats( mapclass& _map, Graphics& _dwgfx )
     doc.SaveFile( (saveFilePath+"unlock.vvv").c_str() );
 }
 
-void Game::customstart( entityclass& obj, musicclass& music )
+void Game::customstart()
 {
     jumpheld = true;
 
@@ -4611,7 +4611,7 @@ void Game::customstart( entityclass& obj, musicclass& music )
     //if (!nocutscenes) music.play(5);
 }
 
-void Game::start( entityclass& obj, musicclass& music )
+void Game::start(musicclass& music )
 {
     jumpheld = true;
 
@@ -4660,7 +4660,7 @@ void Game::deathsequence( mapclass& map, entityclass& obj, musicclass& music )
             gameoverdelay = 60;
         }
         deathcounts++;
-        music.playef(2,10);
+        music.playef(2);
         obj.entities[i].invis = true;
         if (map.finalmode)
         {
@@ -4689,7 +4689,7 @@ void Game::deathsequence( mapclass& map, entityclass& obj, musicclass& music )
     }
 }
 
-void Game::startspecial( int t, entityclass& obj, musicclass& music )
+void Game::startspecial(int t)
 {
     jumpheld = true;
 
@@ -4730,7 +4730,7 @@ void Game::startspecial( int t, entityclass& obj, musicclass& music )
     lifeseq = 0;
 }
 
-void Game::starttrial( int t, entityclass& obj, musicclass& music )
+void Game::starttrial( int t)
 {
     jumpheld = true;
 

--- a/src/Graphics.cpp
+++ b/src/Graphics.cpp
@@ -102,9 +102,6 @@ Graphics::Graphics()
     }
     fadeamount = 0;
     fademode = 0;
-
-
-
 }
 
 Graphics::~Graphics()

--- a/src/Graphics.cpp
+++ b/src/Graphics.cpp
@@ -3042,6 +3042,20 @@ void Graphics::render()
 	}
 }
 
+int Clamp(int const value, int const min, int const max)
+{
+    if (value < min)
+    {
+        return min;
+    }
+    if (value > max)
+    {
+        return max;
+    }
+
+    return value;
+}
+
 void Graphics::bigrprint(int x, int y, std::string& t, int r, int g, int b, bool cen, float sc)
 {
 	r = Clamp(r, 0, 255);
@@ -3092,20 +3106,6 @@ void Graphics::bigrprint(int x, int y, std::string& t, int r, int g, int b, bool
 		}
 		bfontpos+=bfontlen[cur]* sc;
 	}
-}
-
-int Clamp(int const value, int const min, int const max)
-{
-    if (value < min)
-    {
-        return min;
-    }
-    if (value > max)
-    {
-        return max;
-    }
-
-    return value;
 }
 
 void Graphics::drawtele(int x, int y, int t, int c, UtilityClass& help)

--- a/src/Graphics.cpp
+++ b/src/Graphics.cpp
@@ -3044,20 +3044,18 @@ void Graphics::render()
 
 void Graphics::bigrprint(int x, int y, std::string& t, int r, int g, int b, bool cen, float sc)
 {
-	if (r < 0) r = 0;
-	if (g < 0) g = 0;
-	if (b < 0) b = 0;
-	if (r > 255) r = 255;
-	if (g > 255) g = 255;
-	if (b > 255) b = 255;
+	r = Clamp(r, 0, 255);
+	g = Clamp(g, 0, 255);
+	b = Clamp(b, 0, 255);
 	ct.colour = getRGB(r, g, b);
 
 	x = x /  (sc);
 
 	x -= (len(t));
 
-	if (r < -1) r = -1; if (g < 0) g = 0; if (b < 0) b = 0;
-	if (r > 255) r = 255; if (g > 255) g = 255; if (b > 255) b = 255;
+	r = Clamp(r, -1, 255);
+	g = Clamp(g, 0, 255);
+	b = Clamp(b, 0, 255);
 	ct.colour = getRGB(r, g, b);
 
 	if (cen)
@@ -3094,6 +3092,20 @@ void Graphics::bigrprint(int x, int y, std::string& t, int r, int g, int b, bool
 		}
 		bfontpos+=bfontlen[cur]* sc;
 	}
+}
+
+int Clamp(int const value, int const min, int const max)
+{
+    if (value < min)
+    {
+        return min;
+    }
+    if (value > max)
+    {
+        return max;
+    }
+
+    return value;
 }
 
 void Graphics::drawtele(int x, int y, int t, int c, UtilityClass& help)

--- a/src/Graphics.cpp
+++ b/src/Graphics.cpp
@@ -505,14 +505,7 @@ void Graphics::drawsprite( int x, int y, int t, int r, int g,  int b )
     BlitSurfaceColoured(sprites[t], NULL, backBuffer, &rect, ct);
 }
 
-void Graphics::drawtile( int x, int y, int t, int r, int g,  int b )
-{
-    SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
-    BlitSurfaceStandard(tiles[t], NULL, backBuffer, &rect);
-}
-
-
-void Graphics::drawtile2( int x, int y, int t, int r, int g,  int b )
+void Graphics::drawtile2( int x, int y, int t )
 {
     SDL_Rect rect = { Sint16(x), Sint16(y), tiles_rect.w, tiles_rect.h };
     BlitSurfaceStandard(tiles2[t], NULL, backBuffer, &rect);
@@ -1201,7 +1194,7 @@ void Graphics::drawcoloredtile( int x, int y, int t, int r, int g, int b )
 }
 
 
-bool Graphics::Hitest(SDL_Surface* surface1, point p1, int col, SDL_Surface* surface2, point p2, int col2)
+bool Graphics::Hitest(SDL_Surface* surface1, point p1, SDL_Surface* surface2, point p2)
 {
 
     //find rectangle where they intersect:
@@ -2979,7 +2972,6 @@ void Graphics::screenshake()
 		//	screenbuffer.draw(backbuffer, flipmatrix);
 		//	flipmatrix.translate(-tpoint.x, -tpoint.y);
 
-		screenbuffer->ClearScreen(0x000);
 		tpoint.x =  (fRandom() * 7) - 4;
 		tpoint.y =  (fRandom() * 7) - 4;
 		SDL_Rect shakeRect;
@@ -2994,7 +2986,6 @@ void Graphics::screenshake()
 		//SDL_Rect rect;
 		//setRect(rect, blackBars/2, 0, screenbuffer->w, screenbuffer->h);
 		//SDL_BlitSurface(backBuffer, NULL, screenbuffer, &rect);
-		screenbuffer->ClearScreen(0x000);
 		tpoint.x =  static_cast<Sint32>((fRandom() * 7) - 4);
 		tpoint.y =  static_cast<Sint32>((fRandom() * 7) - 4);
 		SDL_Rect shakeRect;

--- a/src/GraphicsResources.cpp
+++ b/src/GraphicsResources.cpp
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 
 #include <SDL2/SDL_assert.h>
+#include <stdexcept>
 
 // Used to load PNG data
 extern "C"
@@ -36,7 +37,11 @@ SDL_Surface* LoadImage(const char *filename, bool noBlend = true, bool noAlpha =
 
 	unsigned char *fileIn = NULL;
 	size_t length = 0;
-	FILESYSTEM_loadFileToMemory(filename, &fileIn, &length);
+	if (!FILESYSTEM_loadFileToMemory(filename, &fileIn, &length))
+	{
+		throw std::runtime_error("Failed to load image file, aborting.");
+	}
+
 	if (noAlpha)
 	{
 		lodepng_decode24(&data, &width, &height, fileIn, length);

--- a/src/GraphicsUtil.cpp
+++ b/src/GraphicsUtil.cpp
@@ -188,16 +188,24 @@ SDL_Surface * ScaleSurfaceSlow( SDL_Surface *_surface, int Width, int Height)
 
 
 	for(Sint32 y = 0; y < _surface->h; y++)
-		for(Sint32 x = 0; x < _surface->w; x++)
+	{
+        for(Sint32 x = 0; x < _surface->w; x++)
+        {
 			for(Sint32 o_y = 0; o_y < _stretch_factor_y; ++o_y)
+            {
 				for(Sint32 o_x = 0; o_x < _stretch_factor_x; ++o_x)
+                {
 					DrawPixel(_ret, static_cast<Sint32>(_stretch_factor_x * x) + o_x,
 					static_cast<Sint32>(_stretch_factor_y * y) + o_y, ReadPixel(_surface, x, y));
+                }
+            }
+        }
+    }
 
-		// DrawPixel(_ret, static_cast<Sint32>(_stretch_factor_x * x) + o_x,
-		//static_cast<Sint32>(_stretch_factor_y * y) + o_y, ReadPixel(_surface, x, y));
+    // DrawPixel(_ret, static_cast<Sint32>(_stretch_factor_x * x) + o_x,
+    //static_cast<Sint32>(_stretch_factor_y * y) + o_y, ReadPixel(_surface, x, y));
 
-		return _ret;
+    return _ret;
 }
 
 SDL_Surface *  FlipSurfaceHorizontal(SDL_Surface* _src)

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -1,13 +1,11 @@
 #include <SDL2/SDL_keycode.h>
 #include <SDL2/SDL_gamecontroller.h>
 #include <Input.h>
+#include <titlerender.h>
 
 #include <MakeAndPlay.h>
 
 #include <tinyxml/tinyxml.h>
-
-// Found in titlerender.cpp
-void updategraphicsmode(Game& game, Graphics& dwgfx);
 
 void updatebuttonmappings(Game& game, KeyPoll& key, musicclass& music, int bind)
 {
@@ -31,7 +29,7 @@ void updatebuttonmappings(Game& game, KeyPoll& key, musicclass& music, int bind)
 				if (!dupe)
 				{
 					game.controllerButton_flip.push_back(i);
-					music.playef(11, 10);
+					music.playef(11);
 				}
 				for (size_t j = 0; j < game.controllerButton_map.size(); j += 1)
 				{
@@ -60,7 +58,7 @@ void updatebuttonmappings(Game& game, KeyPoll& key, musicclass& music, int bind)
 				if (!dupe)
 				{
 					game.controllerButton_map.push_back(i);
-					music.playef(11, 10);
+					music.playef(11);
 				}
 				for (size_t j = 0; j < game.controllerButton_flip.size(); j += 1)
 				{
@@ -89,7 +87,7 @@ void updatebuttonmappings(Game& game, KeyPoll& key, musicclass& music, int bind)
 				if (!dupe)
 				{
 					game.controllerButton_esc.push_back(i);
-					music.playef(11, 10);
+					music.playef(11);
 				}
 				for (size_t j = 0; j < game.controllerButton_flip.size(); j += 1)
 				{
@@ -193,7 +191,7 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
 
         if (key.isDown(27) && game.currentmenuname != "youwannaquit" && game.menustart)
         {
-            music.playef(11, 10);
+            music.playef(11);
             game.previousmenuname = game.currentmenuname;
             game.createmenu("youwannaquit");
             map.nexttowercolour();
@@ -220,7 +218,7 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
             {
                 game.menustart = true;
                 music.play(6);
-                music.playef(18, 10);
+                music.playef(18);
                 game.screenshake = 10;
                 game.flashlight = 5;
                 map.colstate = 10;
@@ -230,26 +228,26 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
             {
                 if (game.currentmenuname == "mainmenu")
                 {
-								
+
 				#if defined(MAKEANDPLAY)
 				   if (game.currentmenuoption == 0)
                     {
                       //Bring you to the normal playmenu
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("playerworlds");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 1)
                     {
                         //Options
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("graphicoptions");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 2)
                     {
                         //Options
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("options");
 
 												//Add extra menu for mmmmmm mod
@@ -265,7 +263,7 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                     else if (game.currentmenuoption == 3)
                     {
                         //bye!
-                        music.playef(2, 10);
+                        music.playef(2);
                         game.mainmenu = 100;
                         dwgfx.fademode = 2;
                     }
@@ -283,7 +281,7 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                         else
                         {
                             //Bring you to the normal playmenu
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.createmenu("play");
                             map.nexttowercolour();
                         }
@@ -291,21 +289,21 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                     else if (game.currentmenuoption == 1)
                     {
                       //Bring you to the normal playmenu
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("playerworlds");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 2)
                     {
                         //Options
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("graphicoptions");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 3)
                     {
                         //Options
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("options");
 
 												//Add extra menu for mmmmmm mod
@@ -321,14 +319,14 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                     else if (game.currentmenuoption == 4)
                     {
                         //Credits
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("credits");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 5)
                     {
                         //bye!
-                        music.playef(2, 10);
+                        music.playef(2);
                         game.mainmenu = 100;
                         dwgfx.fademode = 2;
                     }
@@ -338,12 +336,12 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                 {
                   if(game.currentmenuoption==game.nummenuoptions-1){
                     //go back to menu
-                    music.playef(11, 10);
+                    music.playef(11);
                     game.createmenu("mainmenu");
                     map.nexttowercolour();
                   }else if(game.currentmenuoption==game.nummenuoptions-2){
                     //next page
-                    music.playef(11, 10);
+                    music.playef(11);
                     if((size_t) ((game.levelpage*8)+8) >= ed.ListOfMetaData.size()){
                       game.levelpage=0;
                     }else{
@@ -355,7 +353,7 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                   }else{
                     //Ok, launch the level!
                     //PLAY CUSTOM LEVEL HOOK
-                    music.playef(11, 10);
+                    music.playef(11);
                     game.playcustomlevel=(game.levelpage*8)+game.currentmenuoption;
                     game.customleveltitle=ed.ListOfMetaData[game.playcustomlevel].title;
                     game.customlevelfilename=ed.ListOfMetaData[game.playcustomlevel].filename;
@@ -366,7 +364,7 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
 	                    game.mainmenu = 22;
                       dwgfx.fademode = 2;
 	                  }else{
-                      music.playef(11, 10);
+                      music.playef(11);
                       game.createmenu("quickloadlevel");
                       map.nexttowercolour();
 	                  }
@@ -381,7 +379,7 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
 	                  game.mainmenu = 22;
                     dwgfx.fademode = 2;
                   }else if(game.currentmenuoption==2){
-                    music.playef(11, 10);
+                    music.playef(11);
                     game.levelpage=0;
                     game.createmenu("levellist");
                     map.nexttowercolour();
@@ -391,7 +389,7 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                 {
                   if(game.currentmenuoption==0){
 
-                    music.playef(11, 10);
+                    music.playef(11);
                     game.levelpage=0;
                     ed.getDirectoryData();
                     game.loadcustomlevelstats(); //Should only load a file if it's needed
@@ -399,12 +397,12 @@ void titleinput(KeyPoll& key, Graphics& dwgfx, mapclass& map, Game& game, entity
                     map.nexttowercolour();
                   }else if(game.currentmenuoption==1){
                     //LEVEL EDITOR HOOK
-                    music.playef(11, 10);
+                    music.playef(11);
                     game.mainmenu = 20;
                     dwgfx.fademode = 2;
                     ed.filename="";
                   }/*else if(game.currentmenuoption==2){
-                    music.playef(11, 10);
+                    music.playef(11);
                     //"OPENFOLDERHOOK"
                     //When the player selects the "open level folder" menu option,
                     //this is where it should run the appropriate code.
@@ -415,51 +413,51 @@ SDL_assert(0 && "Remove open level dir");
 
                   }*/else if(game.currentmenuoption==2){
                     //back
-                    music.playef(11, 10);
+                    music.playef(11);
                     game.createmenu("mainmenu");
                     map.nexttowercolour();
                   }
                 }
                 else if(game.currentmenuname=="errornostart"){
-                  music.playef(11, 10);
+                  music.playef(11);
                   game.createmenu("mainmenu");
                   map.nexttowercolour();
                 }
                 else if (game.currentmenuname == "graphicoptions")
                 {
                   if (game.currentmenuoption == 0){
-                    music.playef(11, 10);
+                    music.playef(11);
                     dwgfx.screenbuffer->toggleFullScreen();
-                    music.playef(11, 10);
+                    music.playef(11);
                     game.fullscreen = !game.fullscreen;
-                    updategraphicsmode(game, dwgfx);
+                    updategraphicsmode();
                     game.savestats(map, dwgfx);
                     game.createmenu("graphicoptions");
                     game.currentmenuoption = 0;
                   }else if (game.currentmenuoption == 1){
-                    music.playef(11, 10);
+                    music.playef(11);
                     dwgfx.screenbuffer->toggleStretchMode();
-                    music.playef(11, 10);
+                    music.playef(11);
                     game.stretchMode = (game.stretchMode + 1) % 3;
-                    updategraphicsmode(game, dwgfx);
+                    updategraphicsmode();
                     game.savestats(map, dwgfx);
                     game.createmenu("graphicoptions");
                     game.currentmenuoption = 1;
                   }else if (game.currentmenuoption == 2){
-                    music.playef(11, 10);
+                    music.playef(11);
                     dwgfx.screenbuffer->toggleLinearFilter();
-                    music.playef(11, 10);
+                    music.playef(11);
                     game.useLinearFilter = !game.useLinearFilter;
-                    updategraphicsmode(game, dwgfx);
+                    updategraphicsmode();
                     game.savestats(map, dwgfx);
                     game.createmenu("graphicoptions");
                     game.currentmenuoption = 2;
                   }else if (game.currentmenuoption == 3){
                       //change smoothing
-                      music.playef(11, 10);
+                      music.playef(11);
                       game.fullScreenEffect_badSignal = !game.fullScreenEffect_badSignal;
                       //Hook the analogue thing in here: ABCDEFG
-                      updategraphicsmode(game, dwgfx);
+                      updategraphicsmode();
 					  dwgfx.screenbuffer->badSignalEffect= !dwgfx.screenbuffer->badSignalEffect;
                       game.savestats(map, dwgfx);
                       game.createmenu("graphicoptions");
@@ -468,7 +466,7 @@ SDL_assert(0 && "Remove open level dir");
                   else
                   {
                       //back
-                      music.playef(11, 10);
+                      music.playef(11);
                       game.createmenu("mainmenu");
                       map.nexttowercolour();
                   }
@@ -480,7 +478,7 @@ SDL_assert(0 && "Remove open level dir");
                         {
                             //toggle fullscreen
                             dwgfx.screenbuffer->toggleFullScreen();
-                            music.playef(11, 10);
+                            music.playef(11);
                             if (game.fullscreen)
                             {
                                 game.fullscreen = false;
@@ -489,22 +487,22 @@ SDL_assert(0 && "Remove open level dir");
                             {
                                 game.fullscreen = true;
                             }
-                            updategraphicsmode(game, dwgfx);
+                            updategraphicsmode();
                             game.savestats(map, dwgfx);
                             game.createmenu("graphicoptions");
                         }
                         else if (game.currentmenuoption == 1)
                         {
                             //enable acceleration: if in fullscreen, go back to window first
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.advanced_mode = false;
                             if (game.fullscreen)
                             {
                                 game.fullscreen = false;
-                                updategraphicsmode(game, dwgfx);
+                                updategraphicsmode();
                                 game.fullscreen = true;
                             }
-                            updategraphicsmode(game, dwgfx);
+                            updategraphicsmode();
 
                             game.savestats(map, dwgfx);
                             game.createmenu("graphicoptions");
@@ -513,11 +511,11 @@ SDL_assert(0 && "Remove open level dir");
                         else if (game.currentmenuoption == 2)
                         {
                             //change scaling mode
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.advanced_scaling = (game.advanced_scaling + 1) % 5;
                             dwgfx.screenbuffer->ResizeScreen(320 *game.advanced_scaling,240*game.advanced_scaling );
                             dwgfx.screenbuffer->SetScale(game.advanced_scaling);
-                            updategraphicsmode(game, dwgfx);
+                            updategraphicsmode();
 
                             game.savestats(map, dwgfx);
                             game.createmenu("graphicoptions");
@@ -526,9 +524,9 @@ SDL_assert(0 && "Remove open level dir");
                         else if (game.currentmenuoption == 3)
                         {
                             //change smoothing
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.advanced_smoothing = !game.advanced_smoothing;
-                            updategraphicsmode(game, dwgfx);
+                            updategraphicsmode();
 
                             game.savestats(map, dwgfx);
                             game.createmenu("graphicoptions");
@@ -537,7 +535,7 @@ SDL_assert(0 && "Remove open level dir");
                         else
                         {
                             //back
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.createmenu("mainmenu");
                             map.nexttowercolour();
                         }
@@ -548,7 +546,7 @@ SDL_assert(0 && "Remove open level dir");
                         {
                             dwgfx.screenbuffer->toggleFullScreen();
                             //toggle fullscreen
-                            music.playef(11, 10);
+                            music.playef(11);
                             if (game.fullscreen)
                             {
                                 game.fullscreen = false;
@@ -557,7 +555,7 @@ SDL_assert(0 && "Remove open level dir");
                             {
                                 game.fullscreen = true;
                             }
-                            updategraphicsmode(game, dwgfx);
+                            updategraphicsmode();
 
                             game.savestats(map, dwgfx);
                             game.createmenu("graphicoptions");
@@ -565,15 +563,15 @@ SDL_assert(0 && "Remove open level dir");
                         else if (game.currentmenuoption == 1)
                         {
                             //disable acceleration: if in fullscreen, go back to window first
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.advanced_mode = true;
                             if (game.fullscreen)
                             {
                                 game.fullscreen = false;
-                                updategraphicsmode(game, dwgfx);
+                                updategraphicsmode();
                                 game.fullscreen = true;
                             }
-                            updategraphicsmode(game, dwgfx);
+                            updategraphicsmode();
 
                             game.savestats(map, dwgfx);
                             game.createmenu("graphicoptions");
@@ -582,7 +580,7 @@ SDL_assert(0 && "Remove open level dir");
                         else
                         {
                             //back
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.createmenu("mainmenu");
                             map.nexttowercolour();
                         }
@@ -594,13 +592,13 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //bye!
-                        music.playef(2, 10);
+                        music.playef(2);
                         game.mainmenu = 100;
                         dwgfx.fademode = 2;
                     }
                     else
                     {
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu(game.previousmenuname);
                         map.nexttowercolour();
                     }
@@ -610,7 +608,7 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("accessibility");
                         game.currentmenuoption = 2;
                         map.nexttowercolour();
@@ -621,7 +619,7 @@ SDL_assert(0 && "Remove open level dir");
                         //game.deletequick();
                         //game.deletetele();
                         game.savestats(map, dwgfx);
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("accessibility");
                         game.currentmenuoption = 2;
                         map.nexttowercolour();
@@ -632,7 +630,7 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("accessibility");
                         game.currentmenuoption = 3;
                         map.nexttowercolour();
@@ -644,7 +642,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.deletetele();
                         game.createmenu("setslowdown2");
                         map.nexttowercolour();
-                        music.playef(11, 10);
+                        music.playef(11);
                     }
                 }
                 else if (game.currentmenuname == "setslowdown2")
@@ -655,7 +653,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.gameframerate=34;
                         game.slowdown = 30;
                         game.savestats(map, dwgfx);
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("accessibility");
                         game.currentmenuoption = 3;
                         map.nexttowercolour();
@@ -665,7 +663,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.gameframerate=41;
                         game.slowdown = 24;
                         game.savestats(map, dwgfx);
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("accessibility");
                         game.currentmenuoption = 3;
                         map.nexttowercolour();
@@ -675,7 +673,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.gameframerate=55;
                         game.slowdown = 18;
                         game.savestats(map, dwgfx);
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("accessibility");
                         game.currentmenuoption = 3;
                         map.nexttowercolour();
@@ -685,7 +683,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.gameframerate=83;
                         game.slowdown = 12;
                         game.savestats(map, dwgfx);
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("accessibility");
                         game.currentmenuoption = 3;
                         map.nexttowercolour();
@@ -699,7 +697,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.colourblindmode = !game.colourblindmode;
                         game.savestats(map, dwgfx);
                         map.tdrawback = true;
-                        music.playef(11, 10);
+                        music.playef(11);
                     }
                     else if (game.currentmenuoption == 1)
                     {
@@ -708,7 +706,7 @@ SDL_assert(0 && "Remove open level dir");
                         game.savestats(map, dwgfx);
                         if (!game.noflashingmode)
                         {
-                            music.playef(18, 10);
+                            music.playef(18);
                             game.screenshake = 10;
                             game.flashlight = 5;
                         }
@@ -725,19 +723,19 @@ SDL_assert(0 && "Remove open level dir");
                         {
                             map.invincibility = !map.invincibility;
                         }
-                        music.playef(11, 10);
+                        music.playef(11);
                     }
                     else if (game.currentmenuoption == 3)
                     {
                         //change game speed
                         game.createmenu("setslowdown2");
                         map.nexttowercolour();
-                        music.playef(11, 10);
+                        music.playef(11);
                     }
                     else if (game.currentmenuoption == 4)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("options");
 
 												//Add extra menu for mmmmmm mod
@@ -762,32 +760,32 @@ SDL_assert(0 && "Remove open level dir");
                     else
                     {
                         //Can't do yet! play sad sound
-                        music.playef(2, 10);
+                        music.playef(2);
                     }
                 }
                 else if (game.currentmenuname == "options")
                 {
-								
+
 				#if defined(MAKEANDPLAY)
 				if (game.currentmenuoption == 0)
                     {
                         //accessibility options
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("accessibility");
                         map.nexttowercolour();
                     }
-                   
+
 					else if (game.currentmenuoption == 1)
 					{
 						//clear data menu
-						music.playef(11, 10);
+						music.playef(11);
 						game.createmenu("controller");
 						map.nexttowercolour();
 					}
                     else if (game.currentmenuoption == 2)
                     {
                         //clear data menu
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("cleardatamenu");
                         map.nexttowercolour();
                     }
@@ -802,7 +800,7 @@ SDL_assert(0 && "Remove open level dir");
 														game.usingmmmmmm=1;
 													}
 													music.usingmmmmmm = !music.usingmmmmmm;
-													music.playef(11, 10);
+													music.playef(11);
 													music.play(6);
 													game.savestats(map, dwgfx);
 													game.createmenu("mainmenu");
@@ -811,7 +809,7 @@ SDL_assert(0 && "Remove open level dir");
 											if (game.currentmenuoption == 4)
 											{
 													//back
-													music.playef(11, 10);
+													music.playef(11);
 													game.createmenu("mainmenu");
 													map.nexttowercolour();
 											}
@@ -819,42 +817,42 @@ SDL_assert(0 && "Remove open level dir");
 											if (game.currentmenuoption == 3)
 											{
 													//back
-													music.playef(11, 10);
+													music.playef(11);
 													game.createmenu("mainmenu");
 													map.nexttowercolour();
 											}
 										}
-                    
+
 				#elif !defined(MAKEANDPLAY)
                     if (game.currentmenuoption == 0)
                     {
                         //accessibility options
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("accessibility");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 1)
                     {
                         //unlock play options
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("unlockmenu");
                         map.nexttowercolour();
                     }
 					else if (game.currentmenuoption == 2)
 					{
 						//clear data menu
-						music.playef(11, 10);
+						music.playef(11);
 						game.createmenu("controller");
 						map.nexttowercolour();
 					}
                     else if (game.currentmenuoption == 3)
                     {
                         //clear data menu
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("cleardatamenu");
                         map.nexttowercolour();
                     }
-                    
+
 										if(music.mmmmmm){
 											if (game.currentmenuoption == 4)
 											{
@@ -865,7 +863,7 @@ SDL_assert(0 && "Remove open level dir");
 														game.usingmmmmmm=1;
 													}
 													music.usingmmmmmm = !music.usingmmmmmm;
-													music.playef(11, 10);
+													music.playef(11);
 													music.play(6);
 													game.savestats(map, dwgfx);
 													game.createmenu("mainmenu");
@@ -874,7 +872,7 @@ SDL_assert(0 && "Remove open level dir");
 											if (game.currentmenuoption == 5)
 											{
 													//back
-													music.playef(11, 10);
+													music.playef(11);
 													game.createmenu("mainmenu");
 													map.nexttowercolour();
 											}
@@ -882,7 +880,7 @@ SDL_assert(0 && "Remove open level dir");
 											if (game.currentmenuoption == 4)
 											{
 													//back
-													music.playef(11, 10);
+													music.playef(11);
 													game.createmenu("mainmenu");
 													map.nexttowercolour();
 											}
@@ -895,7 +893,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         game.unlock[9] = true;
                         game.unlocknotify[9] = true;
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.savestats(map, dwgfx);
                         game.createmenu("unlockmenutrials");
                         game.currentmenuoption = 0;
@@ -904,7 +902,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         game.unlock[10] = true;
                         game.unlocknotify[10] = true;
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.savestats(map, dwgfx);
                         game.createmenu("unlockmenutrials");
                         game.currentmenuoption = 1;
@@ -913,7 +911,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         game.unlock[11] = true;
                         game.unlocknotify[11] = true;
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.savestats(map, dwgfx);
                         game.createmenu("unlockmenutrials");
                         game.currentmenuoption = 2;
@@ -922,7 +920,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         game.unlock[12] = true;
                         game.unlocknotify[12] = true;
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.savestats(map, dwgfx);
                         game.createmenu("unlockmenutrials");
                         game.currentmenuoption = 3;
@@ -931,7 +929,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         game.unlock[13] = true;
                         game.unlocknotify[13] = true;
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.savestats(map, dwgfx);
                         game.createmenu("unlockmenutrials");
                         game.currentmenuoption = 4;
@@ -940,7 +938,7 @@ SDL_assert(0 && "Remove open level dir");
                     {
                         game.unlock[14] = true;
                         game.unlocknotify[14] = true;
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.savestats(map, dwgfx);
                         game.createmenu("unlockmenutrials");
                         game.currentmenuoption = 5;
@@ -948,7 +946,7 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 6)   	//back
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("unlockmenu");
                         map.nexttowercolour();
                     }
@@ -958,14 +956,14 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //unlock time trials seperately...
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("unlockmenutrials");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 1)
                     {
                         //unlock intermissions
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.unlock[16] = true;
                         game.unlocknotify[16] = true;
                         game.unlock[6] = true;
@@ -977,7 +975,7 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 2)
                     {
                         //unlock no death mode
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.unlock[17] = true;
                         game.unlocknotify[17] = true;
                         game.savestats(map, dwgfx);
@@ -987,7 +985,7 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 3)
                     {
                         //unlock flip mode
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.unlock[18] = true;
                         game.unlocknotify[18] = true;
                         game.savestats(map, dwgfx);
@@ -997,7 +995,7 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 4)
                     {
                         //unlock jukebox
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.stat_trinkets = 20;
                         game.savestats(map, dwgfx);
                         game.createmenu("unlockmenu");
@@ -1006,7 +1004,7 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 5)
                     {
                         //unlock secret lab
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.unlock[8] = true;
                         game.unlocknotify[8] = true;
                         game.savestats(map, dwgfx);
@@ -1016,7 +1014,7 @@ SDL_assert(0 && "Remove open level dir");
                     else
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("mainmenu");
                         map.nexttowercolour();
                     }
@@ -1026,14 +1024,14 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //next page
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("credits2");
                         map.nexttowercolour();
                     }
                     else
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("mainmenu");
                         map.nexttowercolour();
                     }
@@ -1043,14 +1041,14 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //next page
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("credits25");
                         map.nexttowercolour();
                     }
                     else
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("mainmenu");
                         map.nexttowercolour();
                     }
@@ -1060,14 +1058,14 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //next page
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("credits3");
                         map.nexttowercolour();
                     }
                     else
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("mainmenu");
                         map.nexttowercolour();
                     }
@@ -1077,14 +1075,14 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //next page
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("credits4");
                         map.nexttowercolour();
                     }
                     else
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("mainmenu");
                         map.nexttowercolour();
                     }
@@ -1094,14 +1092,14 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //next page
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("credits5");
                         map.nexttowercolour();
                     }
                     else
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("mainmenu");
                         map.nexttowercolour();
                     }
@@ -1111,14 +1109,14 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //next page
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("credits6");
                         map.nexttowercolour();
                     }
                     else
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("mainmenu");
                         map.nexttowercolour();
                     }
@@ -1128,14 +1126,14 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //next page
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("credits7");
                         map.nexttowercolour();
                     }
                     else
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("mainmenu");
                         map.nexttowercolour();
                     }
@@ -1145,14 +1143,14 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //next page
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("credits8");
                         map.nexttowercolour();
                     }
                     else
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("mainmenu");
                         map.nexttowercolour();
                     }
@@ -1162,14 +1160,14 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //next page
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("credits9");
                         map.nexttowercolour();
                     }
                     else
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("mainmenu");
                         map.nexttowercolour();
                     }
@@ -1179,14 +1177,14 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //first page
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("credits");
                         map.nexttowercolour();
                     }
                     else
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("mainmenu");
                         map.nexttowercolour();
                         music.niceplay(6);
@@ -1213,7 +1211,7 @@ SDL_assert(0 && "Remove open level dir");
                         else
                         {
                             //go to a menu!
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.loadsummary(map, help); //Prepare save slots to display
                             game.createmenu("continue");
                             map.settowercolour(3);
@@ -1222,21 +1220,21 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 1)
                     {
                         //play modes
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("playmodes");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 2)
                     {
                         //newgame
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("newgamewarning");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 3)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("mainmenu");
                         map.nexttowercolour();
                     }
@@ -1263,7 +1261,7 @@ SDL_assert(0 && "Remove open level dir");
                         else
                         {
                             //go to a menu!
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.loadsummary(map, help); //Prepare save slots to display
                             game.createmenu("continue");
                             map.settowercolour(3);
@@ -1276,27 +1274,27 @@ SDL_assert(0 && "Remove open level dir");
                         dwgfx.fademode = 2;
 											}else{
                         //Can't do yet! play sad sound
-                        music.playef(2, 10);
+                        music.playef(2);
 											}
                     }
                     else if (game.currentmenuoption == 2)
                     {
                         //play modes
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("playmodes");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 3)
                     {
                         //newgame
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("newgamewarning");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 4)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("mainmenu");
                         map.nexttowercolour();
                     }
@@ -1314,7 +1312,7 @@ SDL_assert(0 && "Remove open level dir");
                     else
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("play");
                         map.nexttowercolour();
                     }
@@ -1325,7 +1323,7 @@ SDL_assert(0 && "Remove open level dir");
 					if (game.currentmenuoption == 0)
 					{
 						game.controllerSensitivity++;
-						music.playef(11, 10);
+						music.playef(11);
 						if(game.controllerSensitivity > 4)
 						{
 							game.controllerSensitivity = 0;
@@ -1359,7 +1357,7 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("options");
 
 												//Add extra menu for mmmmmm mod
@@ -1383,7 +1381,7 @@ SDL_assert(0 && "Remove open level dir");
                     else
                     {
                         //yep
-                        music.playef(23, 10);
+                        music.playef(23);
                         game.deletequick();
                         game.deletetele();
                         game.deletestats(map, dwgfx);
@@ -1397,26 +1395,26 @@ SDL_assert(0 && "Remove open level dir");
                 {
                     if (game.currentmenuoption == 0  && game.slowdown == 30 && !map.invincibility)   //go to the time trial menu
                     {
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("timetrials");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 1 && game.unlock[16])
                     {
                         //intermission mode menu
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("intermissionmenu");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 2 && game.unlock[17] && game.slowdown == 30 && !map.invincibility)    //start a game in no death mode
                     {
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("startnodeathmode");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 3 && game.unlock[18])    //enable/disable flip mode
                     {
-                        music.playef(18, 10);
+                        music.playef(18);
                         game.screenshake = 10;
                         game.flashlight = 5;
                         dwgfx.setflipmode = !dwgfx.setflipmode;
@@ -1425,14 +1423,14 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 4)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("play");
                         map.nexttowercolour();
                     }
                     else
                     {
                         //Can't do yet! play sad sound
-                        music.playef(2, 10);
+                        music.playef(2);
                     }
                 }
                 else if (game.currentmenuname == "startnodeathmode")
@@ -1450,7 +1448,7 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 2)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("play");
                         map.nexttowercolour();
                     }
@@ -1470,7 +1468,7 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 2)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("play");
                         map.nexttowercolour();
                     }
@@ -1479,14 +1477,14 @@ SDL_assert(0 && "Remove open level dir");
                 {
                     if (game.currentmenuoption == 0)
                     {
-                        music.playef(11, 10);
+                        music.playef(11);
                         music.play(6);
                         game.createmenu("playint1");
                         map.nexttowercolour();
                     }
                     else if (game.currentmenuoption == 1)
                     {
-                        music.playef(11, 10);
+                        music.playef(11);
                         music.play(6);
                         game.createmenu("playint2");
                         map.nexttowercolour();
@@ -1494,7 +1492,7 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 2)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("play");
                         map.nexttowercolour();
                     }
@@ -1524,7 +1522,7 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 4)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("play");
                         map.nexttowercolour();
                     }
@@ -1554,7 +1552,7 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 4)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("play");
                         map.nexttowercolour();
                     }
@@ -1562,7 +1560,7 @@ SDL_assert(0 && "Remove open level dir");
                 else if (game.currentmenuname == "gameover2")
                 {
                     //back
-                    music.playef(11, 10);
+                    music.playef(11);
                     music.play(6);
                     game.createmenu("mainmenu");
                     map.nexttowercolour();
@@ -1570,7 +1568,7 @@ SDL_assert(0 && "Remove open level dir");
                 else if (game.currentmenuname == "unlocktimetrials" || game.currentmenuname == "unlocktimetrial")
                 {
                     //back
-                    music.playef(11, 10);
+                    music.playef(11);
                     game.createmenu("play");
                     map.nexttowercolour();
                 }
@@ -1578,7 +1576,7 @@ SDL_assert(0 && "Remove open level dir");
                          || game.currentmenuname == "unlockflipmode")
                 {
                     //back
-                    music.playef(11, 10);
+                    music.playef(11);
                     game.createmenu("play");
                     map.nexttowercolour();
                 }
@@ -1617,14 +1615,14 @@ SDL_assert(0 && "Remove open level dir");
                     else if (game.currentmenuoption == 6)    //go to the time trial menu
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("play");
                         map.nexttowercolour();
                     }
                     else
                     {
                         //Can't do yet! play sad sound
-                        music.playef(2, 10);
+                        music.playef(2);
                     }
                 }
                 else if (game.currentmenuname == "timetrialcomplete3")
@@ -1632,7 +1630,7 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         //back
-                        music.playef(11, 10);
+                        music.playef(11);
                         music.play(6);
                         game.createmenu("play");
                         map.nexttowercolour();
@@ -1677,7 +1675,7 @@ SDL_assert(0 && "Remove open level dir");
                     if (game.currentmenuoption == 0)
                     {
                         music.play(6);
-                        music.playef(11, 10);
+                        music.playef(11);
                         game.createmenu("play");
                         map.nexttowercolour();
                     }
@@ -1695,11 +1693,11 @@ SDL_assert(0 && "Remove open level dir");
     }
 
     if (dwgfx.fademode == 1)
-        script.startgamemode(game.mainmenu, key, dwgfx, game, map, obj, help, music);
+        script.startgamemode(game.mainmenu, dwgfx, game, map, obj, music);
 }
 
 void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-               entityclass& obj, UtilityClass& help, musicclass& music)
+               entityclass& obj, musicclass& music)
 {
     //TODO mouse input
     //game.mx = (mouseX / 2);
@@ -1856,7 +1854,7 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
     {
         //restart the time trial
         game.quickrestartkludge = false;
-        script.startgamemode(game.timetriallevel + 3, key, dwgfx, game, map, obj, help, music);
+        script.startgamemode(game.timetriallevel + 3, dwgfx, game, map, obj, music);
         game.deathseq = -1;
         game.completestop = false;
     }
@@ -1973,7 +1971,7 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 
                                 int player = obj.getplayer();
                                 obj.entities[player].colour = 102;
-                                int companion = obj.getcompanion(game.companion);
+                                int companion = obj.getcompanion();
                                 if(companion>-1) obj.entities[companion].colour = 102;
 
                                 int teleporter = obj.getteleporter();
@@ -2011,7 +2009,7 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
                     else if (game.intimetrial && dwgfx.fademode==0)
                     {
                         //Quick restart of time trial
-                        script.hardreset(key, dwgfx, game, map, obj, help, music);
+                        script.hardreset(dwgfx, game, map, obj);
                         if (dwgfx.setflipmode) dwgfx.flipmode = true;
                         dwgfx.fademode = 2;
                         game.completestop = true;
@@ -2122,7 +2120,7 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
                         game.gravitycontrol = 1;
                         obj.entities[ie].vy = -4;
                         obj.entities[ie].ay = -3;
-                        music.playef(0, 10);
+                        music.playef(0);
                         game.jumppressed = 0;
                         game.totalflips++;
                     }
@@ -2131,7 +2129,7 @@ void gameinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
                         game.gravitycontrol = 0;
                         obj.entities[ie].vy = 4;
                         obj.entities[ie].ay = 3;
-                        music.playef(1, 10);
+                        music.playef(1);
                         game.jumppressed = 0;
                         game.totalflips++;
                     }
@@ -2290,7 +2288,7 @@ void mapinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
         {
             game.flashlight = 5;
             game.screenshake = 10;
-            music.playef(18, 10);
+            music.playef(18);
             game.gamesaved = true;
 
             game.savetime = game.timestring(help);
@@ -2320,7 +2318,7 @@ void mapinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 				//This fixes an apparent frame flicker.
 				FillRect(dwgfx.tempBuffer, 0x000000);
                 if (game.intimetrial || game.insecretlab || game.nodeathmode) game.menukludge = true;
-                script.hardreset(key, dwgfx, game, map, obj, help, music);
+                script.hardreset(dwgfx, game, map, obj);
                 if(dwgfx.setflipmode) dwgfx.flipmode = true;
                 dwgfx.fademode = 2;
                 music.fadeout();
@@ -2356,7 +2354,7 @@ void mapinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 }
 
 void teleporterinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-                     entityclass& obj, UtilityClass& help, musicclass& music)
+                     entityclass& obj)
 {
     //Todo Mouseinput!
     //game.mx = (mouseX / 2);
@@ -2458,8 +2456,7 @@ void teleporterinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
     }
 }
 
-void gamecompleteinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-                       entityclass& obj, UtilityClass& help, musicclass& music)
+void gamecompleteinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map)
 {
     //game.mx = (mouseX / 2);
     //game.my = (mouseY / 2);
@@ -2503,8 +2500,7 @@ void gamecompleteinput(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
     }
 }
 
-void gamecompleteinput2(KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
-                        entityclass& obj, UtilityClass& help, musicclass& music)
+void gamecompleteinput2(KeyPoll& key, Graphics& dwgfx, Game& game, musicclass& music)
 {
     //TODO Mouse Input!
     //game.mx = (mouseX / 2);

--- a/src/Logic.cpp
+++ b/src/Logic.cpp
@@ -3,7 +3,7 @@
 
 extern int temp;
 
-void titlelogic( Graphics& dwgfx, Game& game, entityclass& obj, UtilityClass& help, musicclass& music, mapclass& map)
+void titlelogic(Game& game, UtilityClass& help, musicclass& music, mapclass& map)
 {
     //Misc
     //map.updatetowerglow();
@@ -25,25 +25,25 @@ void titlelogic( Graphics& dwgfx, Game& game, entityclass& obj, UtilityClass& he
             }
             else if (game.menudest == "gameover2")
             {
-                music.playef(11, 10);
+                music.playef(11);
             }
             else if (game.menudest == "timetrialcomplete3")
             {
-                music.playef(3, 10);
+                music.playef(3);
             }
             game.createmenu(game.menudest);
         }
     }
 }
 
-void maplogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help)
+void maplogic(UtilityClass& help)
 {
     //Misc
     help.updateglow();
 }
 
 
-void gamecompletelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help)
+void gamecompletelogic(Graphics& dwgfx, Game& game, mapclass& map, UtilityClass& help)
 {
     //Misc
     map.updatetowerglow();
@@ -119,7 +119,7 @@ void gamecompletelogic2(Graphics& dwgfx, Game& game, entityclass& obj,  musiccla
         map.colstate = 10;
         game.gamestate = 1;
         dwgfx.fademode = 4;
-        music.playef(18, 10);
+        music.playef(18);
         game.createmenu("gamecompletecontinue");
         map.nexttowercolour();
     }
@@ -276,7 +276,7 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
                 game.gethardestroom(map);
                 //start depressing sequence here...
                 if (game.gameoverdelay <= -10 && dwgfx.fademode==0) dwgfx.fademode = 2;
-                if (dwgfx.fademode == 1) script.resetgametomenu(dwgfx, game, map, obj, help, music);
+                if (dwgfx.fademode == 1) script.resetgametomenu(dwgfx, game, obj);
             }
             else
             {
@@ -309,9 +309,9 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
                 {
                     game.hascontrol = false;
                 }
-                if(game.timetrialcountdown == 120) music.playef(21, 10);
-                if(game.timetrialcountdown == 90) music.playef(21, 10);
-                if(game.timetrialcountdown == 60) music.playef(21, 10);
+                if(game.timetrialcountdown == 120) music.playef(21);
+                if(game.timetrialcountdown == 90) music.playef(21);
+                if(game.timetrialcountdown == 60) music.playef(21);
                 if (game.timetrialcountdown == 30)
                 {
                     switch(game.timetriallevel)
@@ -335,7 +335,7 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
                         music.play(15);
                         break;
                     }
-                    music.playef(22, 10);
+                    music.playef(22);
                 }
             }
 
@@ -350,7 +350,7 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
                     {
                         obj.entities[i].tile = 144;
                     }
-                    music.playef(2, 10);
+                    music.playef(2);
                 }
             }
         }
@@ -521,7 +521,7 @@ void towerlogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& musi
         //Looping around, room change conditions!
     }
 
-    if (game.teleport_to_new_area) script.teleport(dwgfx, game, map,	obj, help, music);
+    if (game.teleport_to_new_area) script.teleport(dwgfx, game, map, obj, music);
 }
 
 void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music, mapclass& map, UtilityClass& help)
@@ -548,7 +548,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
             //change player to sad
             int i = obj.getplayer();
             obj.entities[i].tile = 144;
-            music.playef(2, 10);
+            music.playef(2);
         }
         if (obj.upset > 301) obj.upset = 301;
     }
@@ -638,7 +638,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 game.swndelay = 0;
                 if (game.swntimer >= game.swnrecord)
                 {
-                    if (game.swnmessage == 0) music.playef(25, 10);
+                    if (game.swnmessage == 0) music.playef(25);
                     game.swnmessage = 1;
                     game.swnrecord = game.swntimer;
                 }
@@ -655,7 +655,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 game.gethardestroom(map);
                 //start depressing sequence here...
                 if (game.gameoverdelay <= -10 && dwgfx.fademode==0) dwgfx.fademode = 2;
-                if (dwgfx.fademode == 1) script.resetgametomenu(dwgfx, game, map, obj, help, music);
+                if (dwgfx.fademode == 1) script.resetgametomenu(dwgfx, game, obj);
             }
             else
             {
@@ -699,7 +699,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                             temp = 1+int(fRandom() * 6);
                             if (temp == map.final_mapcol) temp = (temp + 1) % 6;
                             if (temp == 0) temp = 6;
-                            map.changefinalcol(temp, obj,game);
+                            map.changefinalcol(temp, obj);
                         }
                         else if (map.final_colorframe == 2)
                         {
@@ -707,7 +707,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                             temp = 1+int(fRandom() * 6);
                             if (temp == map.final_mapcol) temp = (temp + 1) % 6;
                             if (temp == 0) temp = 6;
-                            map.changefinalcol(temp, obj,game);
+                            map.changefinalcol(temp, obj);
                         }
                     }
                 }
@@ -749,7 +749,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 }
                 else
                 {
-                    obj.generateswnwave(game, help, 0);
+                    obj.generateswnwave(game, 0);
                 }
             }
             else if(game.swngame==1)   //super gravitron game
@@ -765,7 +765,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
 												NETWORK_unlockAchievement("vvvvvvsupgrav5");
                         game.swnbestrank = 1;
                         game.swnmessage = 2+30;
-                        music.playef(26, 10);
+                        music.playef(26);
                     }
                 }
                 else if (game.swntimer >= 300 && game.swnrank == 1)
@@ -776,7 +776,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
 												NETWORK_unlockAchievement("vvvvvvsupgrav10");
                         game.swnbestrank = 2;
                         game.swnmessage = 2+30;
-                        music.playef(26, 10);
+                        music.playef(26);
                     }
                 }
                 else if (game.swntimer >= 450 && game.swnrank == 2)
@@ -787,7 +787,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
 												NETWORK_unlockAchievement("vvvvvvsupgrav15");
                         game.swnbestrank = 3;
                         game.swnmessage = 2+30;
-                        music.playef(26, 10);
+                        music.playef(26);
                     }
                 }
                 else if (game.swntimer >= 600 && game.swnrank == 3)
@@ -798,7 +798,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
 												NETWORK_unlockAchievement("vvvvvvsupgrav20");
                         game.swnbestrank = 4;
                         game.swnmessage = 2+30;
-                        music.playef(26, 10);
+                        music.playef(26);
                     }
                 }
                 else if (game.swntimer >= 900 && game.swnrank == 4)
@@ -809,7 +809,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
 												NETWORK_unlockAchievement("vvvvvvsupgrav30");
                         game.swnbestrank = 5;
                         game.swnmessage = 2+30;
-                        music.playef(26, 10);
+                        music.playef(26);
                     }
                 }
                 else if (game.swntimer >= 1800 && game.swnrank == 5)
@@ -820,11 +820,11 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
 												NETWORK_unlockAchievement("vvvvvvsupgrav60");
                         game.swnbestrank = 6;
                         game.swnmessage = 2+30;
-                        music.playef(26, 10);
+                        music.playef(26);
                     }
                 }
 
-                obj.generateswnwave(game, help, 1);
+                obj.generateswnwave(game, 1);
 
                 game.swncoldelay--;
                 if(game.swncoldelay<=0)
@@ -904,9 +904,9 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 {
                     game.hascontrol = false;
                 }
-                if(game.timetrialcountdown == 120) music.playef(21, 10);
-                if(game.timetrialcountdown == 90) music.playef(21, 10);
-                if(game.timetrialcountdown == 60) music.playef(21, 10);
+                if(game.timetrialcountdown == 120) music.playef(21);
+                if(game.timetrialcountdown == 90) music.playef(21);
+                if(game.timetrialcountdown == 60) music.playef(21);
                 if (game.timetrialcountdown == 30)
                 {
                     switch(game.timetriallevel)
@@ -930,7 +930,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                         music.play(15);
                         break;
                     }
-                    music.playef(22, 10);
+                    music.playef(22);
                 }
             }
 
@@ -945,7 +945,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                     {
                         obj.entities[i].tile = 144;
                     }
-                    music.playef(2, 10);
+                    music.playef(2);
                 }
             }
         }
@@ -997,13 +997,13 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                             obj.updateentitylogic(ie, game);                          // Basic Physics
                             obj.entitymapcollision(ie, map);                          // Collisions with walls
 
-                            obj.hormovingplatformfix(ie, map);
+                            obj.hormovingplatformfix(ie);
                         }
                     }
                 }
                 //is the player standing on a moving platform?
                 int i = obj.getplayer();
-                float j = obj.entitycollideplatformfloor(map, i);
+                float j = obj.entitycollideplatformfloor(i);
                 if (j > -1000)
                 {
                     obj.entities[i].newxp = obj.entities[i].xp + j;
@@ -1011,7 +1011,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                 }
                 else
                 {
-                    j = obj.entitycollideplatformroof(map, i);
+                    j = obj.entitycollideplatformroof(i);
                     if (j > -1000)
                     {
                         obj.entities[i].newxp = obj.entities[i].xp + j;
@@ -1360,7 +1360,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
             {
             case 6:
                 obj.createentity(game, obj.entities[i].xp, 121.0f, 15.0f,1);  //Y=121, the floor in that particular place!
-                j = obj.getcompanion(6);
+                j = obj.getcompanion();
                 obj.entities[j].vx = obj.entities[i].vx;
                 obj.entities[j].dir = obj.entities[i].dir;
                 break;
@@ -1375,7 +1375,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                     {
                         obj.createentity(game, obj.entities[i].xp, 86.0f, 16.0f, 1);  //Y=86, the ROOF in that particular place!
                     }
-                    j = obj.getcompanion(7);
+                    j = obj.getcompanion();
                     obj.entities[j].vx = obj.entities[i].vx;
                     obj.entities[j].dir = obj.entities[i].dir;
                 }
@@ -1386,14 +1386,14 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                     if (game.roomx == 102)
                     {
                         obj.createentity(game, 310, 177, 17, 1);
-                        j = obj.getcompanion(8);
+                        j = obj.getcompanion();
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
                     }
                     else
                     {
                         obj.createentity(game, obj.entities[i].xp, 177.0f, 17.0f, 1);
-                        j = obj.getcompanion(8);
+                        j = obj.getcompanion();
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
                     }
@@ -1410,7 +1410,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                     {
                         obj.createentity(game, obj.entities[i].xp, 185.0f, 18.0f, 15, 0, 1);
                     }
-                    j = obj.getcompanion(9);
+                    j = obj.getcompanion();
                     obj.entities[j].vx = obj.entities[i].vx;
                     obj.entities[j].dir = obj.entities[i].dir;
                 }
@@ -1422,7 +1422,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                     if (obj.flags[59] == 0)
                     {
                         obj.createentity(game, 225.0f, 169.0f, 18, dwgfx.crewcolour(game.lastsaved), 0, 10);
-                        j = obj.getcompanion(10);
+                        j = obj.getcompanion();
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
                     }
@@ -1432,7 +1432,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                     if (obj.flags[59] == 1)
                     {
                         obj.createentity(game, 160.0f, 177.0f, 18, dwgfx.crewcolour(game.lastsaved), 0, 18, 1);
-                        j = obj.getcompanion(10);
+                        j = obj.getcompanion();
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
                     }
@@ -1440,7 +1440,7 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
                     {
                         obj.flags[59] = 1;
                         obj.createentity(game, obj.entities[i].xp, -20.0f, 18.0f, dwgfx.crewcolour(game.lastsaved), 0, 10, 0);
-                        j = obj.getcompanion(10);
+                        j = obj.getcompanion();
                         obj.entities[j].vx = obj.entities[i].vx;
                         obj.entities[j].dir = obj.entities[i].dir;
                     }
@@ -1543,5 +1543,5 @@ void gamelogic(Graphics& dwgfx, Game& game, entityclass& obj,  musicclass& music
     }
 
     if (game.teleport_to_new_area)
-        script.teleport(dwgfx, game, map,	obj, help, music);
+        script.teleport(dwgfx, game, map, obj, music);
 }

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -523,7 +523,7 @@ int mapclass::maptiletoenemycol(int t)
 	return 11;
 }
 
-void mapclass::changefinalcol(int t, entityclass& obj, Game& game)
+void mapclass::changefinalcol(int t, entityclass& obj)
 {
 	//change the map to colour t - for the game's final stretch.
 	//First up, the tiles. This is just a setting:
@@ -1040,7 +1040,7 @@ void mapclass::gotoroom(int rx, int ry, Graphics& dwgfx, Game& game, entityclass
 		if (game.roomx == 104 && game.roomy == 112) music.niceplay(4);
 	}
 	temp = rx + (ry * 100);
-	loadlevel(game.roomx, game.roomy, dwgfx, game, obj, music);
+	loadlevel(game.roomx, game.roomy, dwgfx, game, obj);
 
 
 	dwgfx.backgrounddrawn = false; //Used for background caching speedup
@@ -1152,7 +1152,7 @@ std::string mapclass::currentarea(int t)
 	return "???";
 }
 
-void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclass& obj, musicclass& music)
+void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclass& obj)
 {
 	int t;
 	//t = rx + (ry * 100);
@@ -1404,7 +1404,7 @@ void mapclass::loadlevel(int rx, int ry, Graphics& dwgfx, Game& game, entityclas
 		}
 
 		dwgfx.rcol = 6;
-		changefinalcol(final_mapcol, obj, game);
+		changefinalcol(final_mapcol, obj);
 		break;
 	case 7: //Final Level, Tower 1
 		tdrawback = true;

--- a/src/Music.cpp
+++ b/src/Music.cpp
@@ -439,7 +439,7 @@ void musicclass::initefchannels()
 	// for (var i:int = 0; i < 16; i++) efchannel.push(new SoundChannel);
 }
 
-void musicclass::playef(int t, int offset)
+void musicclass::playef(int t)
 {
 	// efchannel[currentefchan] = efchan[t].play(offset);
 	// currentefchan++;

--- a/src/Screen.cpp
+++ b/src/Screen.cpp
@@ -3,6 +3,7 @@
 #include <GraphicsUtil.h>
 
 #include <stdlib.h>
+#include <stdexcept>
 
 // Used to create the window icon
 extern "C"
@@ -46,7 +47,11 @@ Screen::Screen()
 	size_t length = 0;
 	unsigned char *data;
 	unsigned int width, height;
-	FILESYSTEM_loadFileToMemory("VVVVVV.png", &fileIn, &length);
+	if (!FILESYSTEM_loadFileToMemory("VVVVVV.png", &fileIn, &length))
+	{
+		throw std::runtime_error("Error loading window icon, aborting");
+	}
+
 	lodepng_decode24(&data, &width, &height, fileIn, length);
 	FILESYSTEM_freeMemory(&fileIn);
 	SDL_Surface *icon = SDL_CreateRGBSurfaceFrom(

--- a/src/Screen.cpp
+++ b/src/Screen.cpp
@@ -209,8 +209,3 @@ void Screen::toggleLinearFilter()
 		240
 	);
 }
-
-void Screen::ClearScreen( int colour )
-{
-    //FillRect(m_screen, colour) ;
-}

--- a/src/Script.cpp
+++ b/src/Script.cpp
@@ -225,7 +225,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			}
 			if (words[0] == "playef")
 			{
-				music.playef(ss_toi(words[1]), ss_toi(words[2]));
+				music.playef(ss_toi(words[1]));
 			}
 			if (words[0] == "play")
 			{
@@ -1173,39 +1173,39 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			{
 				if (words[1] == "player")
 				{
-					music.playef(11, 10);
+					music.playef(11);
 				}
 				else if (words[1] == "cyan")
 				{
-					music.playef(11, 10);
+					music.playef(11);
 				}
 				else if (words[1] == "red")
 				{
-					music.playef(16, 10);
+					music.playef(16);
 				}
 				else if (words[1] == "green")
 				{
-					music.playef(12, 10);
+					music.playef(12);
 				}
 				else if (words[1] == "yellow")
 				{
-					music.playef(14, 10);
+					music.playef(14);
 				}
 				else if (words[1] == "blue")
 				{
-					music.playef(13, 10);
+					music.playef(13);
 				}
 				else if (words[1] == "purple")
 				{
-					music.playef(15, 10);
+					music.playef(15);
 				}
 				else if (words[1] == "cry")
 				{
-					music.playef(2, 10);
+					music.playef(2);
 				}
 				else if (words[1] == "terminal")
 				{
-					music.playef(20, 10);
+					music.playef(20);
 				}
 			}
 			else if (words[0] == "blackout")
@@ -1853,7 +1853,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			{
 				//music.silencedasmusik();
 				music.haltdasmusik();
-				music.playef(3,10);
+				music.playef(3);
 
 				game.trinkets++;
 				obj.collect[ss_toi(words[1])] = 1;
@@ -1880,7 +1880,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 			}
 			else if (words[0] == "foundlab")
 			{
-				music.playef(3,10);
+				music.playef(3);
 
 				dwgfx.textboxremovefast();
 
@@ -2496,7 +2496,7 @@ void scriptclass::run( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map,
 	}
 }
 
-void scriptclass::resetgametomenu( Graphics& dwgfx, Game& game,mapclass& map, entityclass& obj, UtilityClass& help, musicclass& music )
+void scriptclass::resetgametomenu( Graphics& dwgfx, Game& game, entityclass& obj )
 {
 	game.gamestate = TITLEMODE;
 	dwgfx.flipmode = false;
@@ -2505,14 +2505,14 @@ void scriptclass::resetgametomenu( Graphics& dwgfx, Game& game,mapclass& map, en
 	game.createmenu("gameover");
 }
 
-void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help, musicclass& music )
+void scriptclass::startgamemode( int t, Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, musicclass& music )
 {
 	switch(t)
 	{
 	case 0:  //Normal new game
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
-		game.start(obj, music);
+		hardreset(dwgfx, game, map, obj);
+		game.start(music);
 		game.jumpheld = true;
 		dwgfx.showcutscenebars = true;
 		dwgfx.cutscenebarspos = 320;
@@ -2534,8 +2534,8 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 1:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
-		game.start(obj, music);
+		hardreset(dwgfx, game, map, obj);
+		game.start(music);
 		game.loadtele(map, obj, music);
 		game.gravitycontrol = game.savegc;
 		game.jumpheld = true;
@@ -2556,8 +2556,8 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 2: //Load Quicksave
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
-		game.start(obj, music);
+		hardreset(dwgfx, game, map, obj);
+		game.start(music);
 		game.loadquick(map, obj, music);
 		game.gravitycontrol = game.savegc;
 		game.jumpheld = true;
@@ -2589,7 +2589,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 3:
 		//Start Time Trial 1
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset(dwgfx, game, map, obj);
 		game.nocutscenes = true;
 		game.intimetrial = true;
 		game.timetrialcountdown = 150;
@@ -2600,7 +2600,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		music.fadeout();
 		game.gamestate = GAMEMODE;
-		game.starttrial(game.timetriallevel, obj, music);
+		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
@@ -2617,7 +2617,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 4:
 		//Start Time Trial 2
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset(dwgfx, game, map, obj);
 		game.nocutscenes = true;
 		game.intimetrial = true;
 		game.timetrialcountdown = 150;
@@ -2628,7 +2628,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		music.fadeout();
 		game.gamestate = GAMEMODE;
-		game.starttrial(game.timetriallevel, obj, music);
+		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
@@ -2645,7 +2645,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 5:
 		//Start Time Trial 3 tow
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset(dwgfx, game, map, obj);
 		game.nocutscenes = true;
 		game.intimetrial = true;
 		game.timetrialcountdown = 150;
@@ -2656,7 +2656,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		music.fadeout();
 		game.gamestate = GAMEMODE;
-		game.starttrial(game.timetriallevel, obj, music);
+		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
@@ -2673,7 +2673,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 6:
 		//Start Time Trial 4 station
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset(dwgfx, game, map, obj);
 		game.nocutscenes = true;
 		game.intimetrial = true;
 		game.timetrialcountdown = 150;
@@ -2684,7 +2684,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		music.fadeout();
 		game.gamestate = GAMEMODE;
-		game.starttrial(game.timetriallevel, obj, music);
+		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
@@ -2701,7 +2701,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 7:
 		//Start Time Trial 5 warp
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset(dwgfx, game, map, obj);
 		game.nocutscenes = true;
 		game.intimetrial = true;
 		game.timetrialcountdown = 150;
@@ -2712,7 +2712,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
 		music.fadeout();
 		game.gamestate = GAMEMODE;
-		game.starttrial(game.timetriallevel, obj, music);
+		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
@@ -2729,7 +2729,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 8:
 		//Start Time Trial 6// final level!
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset(dwgfx, game, map, obj);
 		game.nocutscenes = true;
 		game.intimetrial = true;
 		game.timetrialcountdown = 150;
@@ -2746,7 +2746,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
 		game.gamestate = GAMEMODE;
-		game.starttrial(game.timetriallevel, obj, music);
+		game.starttrial(game.timetriallevel);
 		game.jumpheld = true;
 
 		if (dwgfx.setflipmode) dwgfx.flipmode = true;//set flipmode
@@ -2763,9 +2763,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 9:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset(dwgfx, game, map, obj);
 		game.nodeathmode = true;
-		game.start(obj, music);
+		game.start(music);
 		game.jumpheld = true;
 		dwgfx.showcutscenebars = true;
 		dwgfx.cutscenebarspos = 320;
@@ -2790,11 +2790,11 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 10:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset(dwgfx, game, map, obj);
 		game.nodeathmode = true;
 		game.nocutscenes = true;
 
-		game.start(obj, music);
+		game.start(music);
 		game.jumpheld = true;
 		dwgfx.showcutscenebars = true;
 		dwgfx.cutscenebarspos = 320;
@@ -2819,9 +2819,9 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 11:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset(dwgfx, game, map, obj);
 
-		game.startspecial(0, obj, music);
+		game.startspecial(0);
 		game.jumpheld = true;
 
 		//Secret lab, so reveal the map, give them all 20 trinkets
@@ -2854,7 +2854,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 12:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset(dwgfx, game, map, obj);
 		music.fadeout();
 
 		game.lastsaved = 2;
@@ -2870,7 +2870,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
-		game.startspecial(1, obj, music);
+		game.startspecial(1);
 		game.jumpheld = true;
 
 		//set flipmode
@@ -2889,7 +2889,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 13:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset(dwgfx, game, map, obj);
 		music.fadeout();
 
 		game.lastsaved = 3;
@@ -2905,7 +2905,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
-		game.startspecial(1, obj, music);
+		game.startspecial(1);
 		game.jumpheld = true;
 
 		//set flipmode
@@ -2924,7 +2924,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 14:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset(dwgfx, game, map, obj);
 		music.fadeout();
 
 		game.lastsaved = 4;
@@ -2940,7 +2940,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
-		game.startspecial(1, obj, music);
+		game.startspecial(1);
 		game.jumpheld = true;
 
 		//set flipmode
@@ -2959,7 +2959,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 15:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset(dwgfx, game, map, obj);
 		music.fadeout();
 
 		game.lastsaved = 5;
@@ -2975,7 +2975,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
-		game.startspecial(1, obj, music);
+		game.startspecial(1);
 		game.jumpheld = true;
 
 		//set flipmode
@@ -2994,7 +2994,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 16:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset(dwgfx, game, map, obj);
 		music.fadeout();
 
 		game.lastsaved = 2;
@@ -3007,7 +3007,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
-		game.startspecial(1, obj, music);
+		game.startspecial(1);
 		game.jumpheld = true;
 
 		//set flipmode
@@ -3026,7 +3026,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 17:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset(dwgfx, game, map, obj);
 		music.fadeout();
 
 		game.lastsaved = 3;
@@ -3039,7 +3039,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
-		game.startspecial(1, obj, music);
+		game.startspecial(1);
 		game.jumpheld = true;
 
 		//set flipmode
@@ -3058,7 +3058,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 18:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset(dwgfx, game, map, obj);
 		music.fadeout();
 
 		game.lastsaved = 4;
@@ -3071,7 +3071,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
-		game.startspecial(1, obj, music);
+		game.startspecial(1);
 		game.jumpheld = true;
 
 		//set flipmode
@@ -3090,7 +3090,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 19:
 		game.gamestate = GAMEMODE;
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset(dwgfx, game, map, obj);
 		music.fadeout();
 
 		game.lastsaved = 5;
@@ -3103,7 +3103,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		map.final_colormode = false;
 		map.final_mapcol = 0;
 		map.final_colorframe = 0;
-		game.startspecial(1, obj, music);
+		game.startspecial(1);
 		game.jumpheld = true;
 
 		//set flipmode
@@ -3122,7 +3122,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 		break;
 	case 20:
 		//Level editor
-		hardreset(key, dwgfx, game, map, obj, help, music);
+		hardreset(dwgfx, game, map, obj);
 		ed.reset();
 		music.fadeout();
 
@@ -3144,8 +3144,8 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 	case 21:  //play custom level (in editor)
 		game.gamestate = GAMEMODE;
 		music.fadeout();
-		hardreset(key, dwgfx, game, map, obj, help, music);
-		game.customstart(obj, music);
+		hardreset(dwgfx, game, map, obj);
+		game.customstart();
 		game.jumpheld = true;
 
 
@@ -3183,8 +3183,8 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
     game.gamestate = GAMEMODE;
     music.fadeout();
-    hardreset(key, dwgfx, game, map, obj, help, music);
-    game.customstart(obj, music);
+    hardreset(dwgfx, game, map, obj);
+    game.customstart();
     game.jumpheld = true;
 
 		map.custommodeforreal = true;
@@ -3226,13 +3226,13 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 
     game.gamestate = GAMEMODE;
     music.fadeout();
-    hardreset(key, dwgfx, game, map, obj, help, music);
+    hardreset(dwgfx, game, map, obj);
 		map.custommodeforreal = true;
     map.custommode = true;
     map.customx = 100;
     map.customy = 100;
 
-    game.customstart(obj, music);
+    game.customstart();
 		game.customloadquick(ed.ListOfMetaData[game.playcustomlevel].filename, map, obj, music);
     game.jumpheld = true;
     game.gravitycontrol = game.savegc;
@@ -3273,7 +3273,7 @@ void scriptclass::startgamemode( int t, KeyPoll& key, Graphics& dwgfx, Game& gam
 	}
 }
 
-void scriptclass::teleport( Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, UtilityClass& help, musicclass& music )
+void scriptclass::teleport( Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, musicclass& music )
 {
 	//er, ok! Teleport to a new area, so!
 	//A general rule of thumb: if you teleport with a companion, get rid of them!
@@ -3381,7 +3381,7 @@ void scriptclass::teleport( Graphics& dwgfx, Game& game, mapclass& map, entitycl
 	}
 }
 
-void scriptclass::hardreset( KeyPoll& key, Graphics& dwgfx, Game& game,mapclass& map, entityclass& obj, UtilityClass& help, musicclass& music )
+void scriptclass::hardreset( Graphics& dwgfx, Game& game,mapclass& map, entityclass& obj )
 {
 	//Game:
 	game.hascontrol = true;

--- a/src/SoundSystem.cpp
+++ b/src/SoundSystem.cpp
@@ -1,6 +1,7 @@
 #include <SDL2/SDL.h>
 #include <SoundSystem.h>
 #include <FileSystemUtils.h>
+#include <stdexcept>
 
 MusicTrack::MusicTrack(const char* fileName)
 {
@@ -30,7 +31,11 @@ SoundTrack::SoundTrack(const char* fileName)
 
 	unsigned char *mem;
 	size_t length = 0;
-	FILESYSTEM_loadFileToMemory(fileName, &mem, &length);
+	if (!FILESYSTEM_loadFileToMemory(fileName, &mem, &length))
+	{
+		throw std::runtime_error("Failed to load soundtrack file, aborting.");
+	}
+
 	SDL_RWops *fileIn = SDL_RWFromMem(mem, length);
 	sound = Mix_LoadWAV_RW(fileIn, 1);
 	FILESYSTEM_freeMemory(&mem);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -2387,7 +2387,7 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
             for (int i = 0; i < 40; i++)
             {
                 temp=ed.contents[i + (ed.levx*40) + ed.vmult[j+(ed.levy*30)]];
-                if(temp>0) dwgfx.drawtile(i*8,j*8,temp,0,0,0);
+                if(temp>0) dwgfx.drawtile(i*8,j*8,temp);
             }
         }
     }
@@ -2398,7 +2398,7 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
             for (int i = 0; i < 40; i++)
             {
                 temp=ed.contents[i + (ed.levx*40) + ed.vmult[j+(ed.levy*30)]];
-                if(temp>0) dwgfx.drawtile2(i*8,j*8,temp,0,0,0);
+                if(temp>0) dwgfx.drawtile2(i*8,j*8,temp);
             }
         }
     }
@@ -2823,22 +2823,22 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
             {
                 for(int i=0; i<40; i++)
                 {
-                    dwgfx.drawtile(i*8,0-t2,(temp+1200+i)%1200,0,0,0);
-                    dwgfx.drawtile(i*8,8-t2,(temp+1200+40+i)%1200,0,0,0);
-                    dwgfx.drawtile(i*8,16-t2,(temp+1200+80+i)%1200,0,0,0);
-                    dwgfx.drawtile(i*8,24-t2,(temp+1200+120+i)%1200,0,0,0);
-                    dwgfx.drawtile(i*8,32-t2,(temp+1200+160+i)%1200,0,0,0);
+                    dwgfx.drawtile(i*8,0-t2,(temp+1200+i)%1200);
+                    dwgfx.drawtile(i*8,8-t2,(temp+1200+40+i)%1200);
+                    dwgfx.drawtile(i*8,16-t2,(temp+1200+80+i)%1200);
+                    dwgfx.drawtile(i*8,24-t2,(temp+1200+120+i)%1200);
+                    dwgfx.drawtile(i*8,32-t2,(temp+1200+160+i)%1200);
                 }
             }
             else
             {
                 for(int i=0; i<40; i++)
                 {
-                    dwgfx.drawtile2(i*8,0-t2,(temp+1200+i)%1200,0,0,0);
-                    dwgfx.drawtile2(i*8,8-t2,(temp+1200+40+i)%1200,0,0,0);
-                    dwgfx.drawtile2(i*8,16-t2,(temp+1200+80+i)%1200,0,0,0);
-                    dwgfx.drawtile2(i*8,24-t2,(temp+1200+120+i)%1200,0,0,0);
-                    dwgfx.drawtile2(i*8,32-t2,(temp+1200+160+i)%1200,0,0,0);
+                    dwgfx.drawtile2(i*8,0-t2,(temp+1200+i)%1200);
+                    dwgfx.drawtile2(i*8,8-t2,(temp+1200+40+i)%1200);
+                    dwgfx.drawtile2(i*8,16-t2,(temp+1200+80+i)%1200);
+                    dwgfx.drawtile2(i*8,24-t2,(temp+1200+120+i)%1200);
+                    dwgfx.drawtile2(i*8,32-t2,(temp+1200+160+i)%1200);
                 }
             }
             //Highlight our little block
@@ -2855,11 +2855,11 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
 
             if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset==0)
             {
-                dwgfx.drawtile(45,45-t2,ed.dmtile,0,0,0);
+                dwgfx.drawtile(45,45-t2,ed.dmtile);
             }
             else
             {
-                dwgfx.drawtile2(45,45-t2,ed.dmtile,0,0,0);
+                dwgfx.drawtile2(45,45-t2,ed.dmtile);
             }
         }
         else
@@ -2871,11 +2871,11 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
 
             if(ed.level[ed.levx+(ed.levy*ed.maxwidth)].tileset==0)
             {
-                dwgfx.drawtile(45,12,ed.dmtile,0,0,0);
+                dwgfx.drawtile(45,12,ed.dmtile);
             }
             else
             {
-                dwgfx.drawtile2(45,12,ed.dmtile,0,0,0);
+                dwgfx.drawtile2(45,12,ed.dmtile);
             }
         }
     }
@@ -3262,19 +3262,19 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
                 }
                 FillRect(dwgfx.backBuffer, 4+(ed.drawmode*tg), 209,20,20,dwgfx.getRGB(64,64,64));
                 //0:
-                dwgfx.drawtile(tx,ty,83,0,0,0);
-                dwgfx.drawtile(tx+8,ty,83,0,0,0);
-                dwgfx.drawtile(tx,ty+8,83,0,0,0);
-                dwgfx.drawtile(tx+8,ty+8,83,0,0,0);
+                dwgfx.drawtile(tx,ty,83);
+                dwgfx.drawtile(tx+8,ty,83);
+                dwgfx.drawtile(tx,ty+8,83);
+                dwgfx.drawtile(tx+8,ty+8,83);
                 //1:
                 tx+=tg;
-                dwgfx.drawtile(tx,ty,680,0,0,0);
-                dwgfx.drawtile(tx+8,ty,680,0,0,0);
-                dwgfx.drawtile(tx,ty+8,680,0,0,0);
-                dwgfx.drawtile(tx+8,ty+8,680,0,0,0);
+                dwgfx.drawtile(tx,ty,680);
+                dwgfx.drawtile(tx+8,ty,680);
+                dwgfx.drawtile(tx,ty+8,680);
+                dwgfx.drawtile(tx+8,ty+8,680);
                 //2:
                 tx+=tg;
-                dwgfx.drawtile(tx+4,ty+4,8,0,0,0);
+                dwgfx.drawtile(tx+4,ty+4,8);
                 //3:
                 tx+=tg;
                 dwgfx.drawsprite(tx,ty,22,196,196,196);
@@ -3283,16 +3283,16 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
                 dwgfx.drawsprite(tx,ty,21,196,196,196);
                 //5:
                 tx+=tg;
-                dwgfx.drawtile(tx,ty+4,3,0,0,0);
-                dwgfx.drawtile(tx+8,ty+4,4,0,0,0);
+                dwgfx.drawtile(tx,ty+4,3);
+                dwgfx.drawtile(tx+8,ty+4,4);
                 //6:
                 tx+=tg;
-                dwgfx.drawtile(tx,ty+4,24,0,0,0);
-                dwgfx.drawtile(tx+8,ty+4,24,0,0,0);
+                dwgfx.drawtile(tx,ty+4,24);
+                dwgfx.drawtile(tx+8,ty+4,24);
                 //7:
                 tx+=tg;
-                dwgfx.drawtile(tx,ty+4,1,0,0,0);
-                dwgfx.drawtile(tx+8,ty+4,1,0,0,0);
+                dwgfx.drawtile(tx,ty+4,1);
+                dwgfx.drawtile(tx+8,ty+4,1);
                 //8:
                 tx+=tg;
                 dwgfx.drawsprite(tx,ty,78+ed.entframe,196,196,196);
@@ -3596,7 +3596,7 @@ void editorrender( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, ent
     //dwgfx.backbuffer.unlock();
 }
 
-void editorlogic( KeyPoll& key, Graphics& dwgfx, Game& game, entityclass& obj, musicclass& music, mapclass& map, UtilityClass& help )
+void editorlogic( Graphics& dwgfx, Game& game, musicclass& music, mapclass& map, UtilityClass& help )
 {
     //Misc
     help.updateglow();
@@ -4115,7 +4115,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                         }
                         else if (game.currentmenuoption == 4)
                         {
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.createmenu("ed_settings");
                             map.nexttowercolour();
                         }
@@ -4125,14 +4125,14 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                         if (game.currentmenuoption == 0)
                         {
                             //Change level description stuff
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.createmenu("ed_desc");
                             map.nexttowercolour();
                         }
                         else if (game.currentmenuoption == 1)
                         {
                             //Enter script editormode
-                            music.playef(11, 10);
+                            music.playef(11);
                             ed.scripteditmod=true;
                             ed.clearscriptbuffer();
                             key.enabletextentry();
@@ -4146,7 +4146,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                         }
                         else if (game.currentmenuoption == 2)
                         {
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.createmenu("ed_music");
                             map.nexttowercolour();
                             if(ed.levmusic>0) music.play(ed.levmusic);
@@ -4183,7 +4183,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                         }
                         else if (game.currentmenuoption == 5)
                         {
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.createmenu("ed_quit");
                             map.nexttowercolour();
                         }
@@ -4205,11 +4205,11 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                             {
                                 music.haltdasmusik();
                             }
-                            music.playef(11, 10);
+                            music.playef(11);
                         }
                         else if (game.currentmenuoption == 1)
                         {
-                            music.playef(11, 10);
+                            music.playef(11);
                             music.fadeout();
                             game.createmenu("ed_settings");
                             map.nexttowercolour();
@@ -4237,14 +4237,14 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
                         else if (game.currentmenuoption == 1)
                         {
                             //Quit without saving
-                            music.playef(11, 10);
+                            music.playef(11);
                             music.fadeout();
                             dwgfx.fademode = 2;
                         }
                         else if (game.currentmenuoption == 2)
                         {
                             //Go back to editor
-                            music.playef(11, 10);
+                            music.playef(11);
                             game.createmenu("ed_settings");
                             map.nexttowercolour();
                         }
@@ -4546,7 +4546,7 @@ void editorinput( KeyPoll& key, Graphics& dwgfx, Game& game, mapclass& map, enti
 
                         music.stopmusic();
                         dwgfx.backgrounddrawn=false;
-                        script.startgamemode(21, key, dwgfx, game, map, obj, help, music);
+                        script.startgamemode(21, dwgfx, game, map, obj, music);
                     }
                     //Return to game
                     //game.gamestate=GAMEMODE;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,16 +84,10 @@ int main(int argc, char *argv[])
 
     //Set up screen
 
-
-
-
     UtilityClass help;
     // Load Ini
 
-
     Graphics graphics;
-
-
 
     musicclass music;
     Game game;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -336,20 +336,20 @@ int main(int argc, char *argv[])
                 //Render
                 editorrender(key, graphics, game, map, obj, help);
                 ////Logic
-                editorlogic(key, graphics, game, obj, music, map, help);
+                editorlogic(graphics, game, music, map, help);
                 break;
             case TITLEMODE:
                 //Input
                 titleinput(key, graphics, map, game, obj, help, music);
                 //Render
-                titlerender(graphics, map, game, obj, help, music);
+                titlerender(graphics, map, game, help, music);
                 ////Logic
-                titlelogic(graphics, game, obj, help, music, map);
+                titlelogic(game, help, music, map);
                 break;
             case GAMEMODE:
                 if (map.towermode)
                 {
-					gameinput(key, graphics, game, map, obj, help, music);
+					gameinput(key, graphics, game, map, obj, music);
 
                     //if(game.recording==1)
                     //{
@@ -376,10 +376,10 @@ int main(int argc, char *argv[])
                             script.run(key, graphics, game, map, obj, help, music);
                         }
 
-                        gameinput(key, graphics, game, map, obj, help, music);
+                        gameinput(key, graphics, game, map, obj, music);
                         //}
-                        gamerender(graphics,map, game,  obj, help);
-                        gamelogic(graphics, game,obj, music, map,  help);
+                        gamerender(graphics,map, game, obj, help);
+                        gamelogic(graphics, game, obj, music, map, help);
 
 
                     }
@@ -394,7 +394,7 @@ int main(int argc, char *argv[])
                     {
                         mapinput(key, graphics, game, map, obj, help, music);
                     }
-                    maplogic(graphics, game, obj ,music , map, help );
+                    maplogic(help);
                     break;
                 case TELEPORTERMODE:
                     teleporterrender(graphics, game, map, obj, help);
@@ -406,7 +406,7 @@ int main(int argc, char *argv[])
                     {
                         if(game.useteleporter)
                         {
-                            teleporterinput(key, graphics, game, map, obj, help, music);
+                            teleporterinput(key, graphics, game, map, obj);
                         }
                         else
                         {
@@ -414,22 +414,22 @@ int main(int argc, char *argv[])
                             {
                                 script.run(key, graphics, game, map, obj, help, music);
                             }
-                            gameinput(key, graphics, game, map, obj, help, music);
+                            gameinput(key, graphics, game, map, obj, music);
                         }
                     }
-                    maplogic(graphics, game,  obj, music, map, help);
+                    maplogic(help);
                     break;
                 case GAMECOMPLETE:
-                    gamecompleterender(graphics, game, obj, help, map);
+                    gamecompleterender(graphics, game, help, map);
                     //Input
-                    gamecompleteinput(key, graphics, game, map, obj, help, music);
+                    gamecompleteinput(key, graphics, game, map);
                     //Logic
-                    gamecompletelogic(graphics, game,  obj, music, map, help);
+                    gamecompletelogic(graphics, game, map, help);
                     break;
                 case GAMECOMPLETE2:
-                    gamecompleterender2(graphics, game, obj, help);
+                    gamecompleterender2(graphics, game);
                     //Input
-                    gamecompleteinput2(key, graphics, game, map, obj, help, music);
+                    gamecompleteinput2(key, graphics, game, music);
                     //Logic
                     gamecompletelogic2(graphics, game,  obj, music, map, help);
                     break;

--- a/src/tinyxml/tinyxmlparser.cpp
+++ b/src/tinyxml/tinyxmlparser.cpp
@@ -2,23 +2,23 @@
 www.sourceforge.net/projects/tinyxml
 Original code by Lee Thomason (www.grinninglizard.com)
 
-This software is provided 'as-is', without any express or implied 
-warranty. In no event will the authors be held liable for any 
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any
 damages arising from the use of this software.
 
-Permission is granted to anyone to use this software for any 
-purpose, including commercial applications, and to alter it and 
+Permission is granted to anyone to use this software for any
+purpose, including commercial applications, and to alter it and
 redistribute it freely, subject to the following restrictions:
 
-1. The origin of this software must not be misrepresented; you must 
+1. The origin of this software must not be misrepresented; you must
 not claim that you wrote the original software. If you use this
 software in a product, an acknowledgment in the product documentation
 would be appreciated but is not required.
 
-2. Altered source versions must be plainly marked as such, and 
+2. Altered source versions must be plainly marked as such, and
 must not be misrepresented as being the original software.
 
-3. This notice may not be removed or altered from any source 
+3. This notice may not be removed or altered from any source
 distribution.
 */
 
@@ -39,8 +39,8 @@ distribution.
 
 // Note tha "PutString" hardcodes the same list. This
 // is less flexible than it appears. Changing the entries
-// or order will break putstring.	
-TiXmlBase::Entity TiXmlBase::entity[ TiXmlBase::NUM_ENTITY ] = 
+// or order will break putstring.
+TiXmlBase::Entity TiXmlBase::entity[ TiXmlBase::NUM_ENTITY ] =
 {
 	{ "&amp;",  5, '&' },
 	{ "&lt;",   4, '<' },
@@ -54,16 +54,16 @@ TiXmlBase::Entity TiXmlBase::entity[ TiXmlBase::NUM_ENTITY ] =
 // Including the basic of this table, which determines the #bytes in the
 // sequence from the lead byte. 1 placed for invalid sequences --
 // although the result will be junk, pass it through as much as possible.
-// Beware of the non-characters in UTF-8:	
+// Beware of the non-characters in UTF-8:
 //				ef bb bf (Microsoft "lead bytes")
 //				ef bf be
-//				ef bf bf 
+//				ef bf bf
 
 const unsigned char TIXML_UTF_LEAD_0 = 0xefU;
 const unsigned char TIXML_UTF_LEAD_1 = 0xbbU;
 const unsigned char TIXML_UTF_LEAD_2 = 0xbfU;
 
-const int TiXmlBase::utf8ByteTable[256] = 
+const int TiXmlBase::utf8ByteTable[256] =
 {
 	//	0	1	2	3	4	5	6	7	8	9	a	b	c	d	e	f
 		1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	// 0x00
@@ -75,9 +75,9 @@ const int TiXmlBase::utf8ByteTable[256] =
 		1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	// 0x60
 		1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	// 0x70	End of ASCII range
 		1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	// 0x80 0x80 to 0xc1 invalid
-		1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	// 0x90 
-		1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	// 0xa0 
-		1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	// 0xb0 
+		1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	// 0x90
+		1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	// 0xa0
+		1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	// 0xb0
 		1,	1,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	// 0xc0 0xc2 to 0xdf 2 byte
 		2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	// 0xd0
 		3,	3,	3,	3,	3,	3,	3,	3,	3,	3,	3,	3,	3,	3,	3,	3,	// 0xe0 0xe0 to 0xef 3 byte
@@ -91,7 +91,7 @@ void TiXmlBase::ConvertUTF32ToUTF8( unsigned long input, char* output, int* leng
 	const unsigned long BYTE_MARK = 0x80;
 	const unsigned long FIRST_BYTE_MARK[7] = { 0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC };
 
-	if (input < 0x80) 
+	if (input < 0x80)
 		*length = 1;
 	else if ( input < 0x800 )
 		*length = 2;
@@ -105,23 +105,25 @@ void TiXmlBase::ConvertUTF32ToUTF8( unsigned long input, char* output, int* leng
 	output += *length;
 
 	// Scary scary fall throughs.
-	switch (*length) 
+	switch (*length)
 	{
 		case 4:
-			--output; 
-			*output = (char)((input | BYTE_MARK) & BYTE_MASK); 
+			--output;
+			*output = (char)((input | BYTE_MARK) & BYTE_MASK);
 			input >>= 6;
 		case 3:
-			--output; 
-			*output = (char)((input | BYTE_MARK) & BYTE_MASK); 
+			--output;
+			*output = (char)((input | BYTE_MARK) & BYTE_MASK);
 			input >>= 6;
 		case 2:
-			--output; 
-			*output = (char)((input | BYTE_MARK) & BYTE_MASK); 
+			--output;
+			*output = (char)((input | BYTE_MARK) & BYTE_MASK);
 			input >>= 6;
 		case 1:
-			--output; 
+			--output;
 			*output = (char)(input | FIRST_BYTE_MARK[*length]);
+		default:
+			break;
 	}
 }
 
@@ -130,7 +132,7 @@ void TiXmlBase::ConvertUTF32ToUTF8( unsigned long input, char* output, int* leng
 {
 	// This will only work for low-ascii, everything else is assumed to be a valid
 	// letter. I'm not sure this is the best approach, but it is quite tricky trying
-	// to figure out alhabetical vs. not across encoding. So take a very 
+	// to figure out alhabetical vs. not across encoding. So take a very
 	// conservative approach.
 
 //	if ( encoding == TIXML_ENCODING_UTF8 )
@@ -151,7 +153,7 @@ void TiXmlBase::ConvertUTF32ToUTF8( unsigned long input, char* output, int* leng
 {
 	// This will only work for low-ascii, everything else is assumed to be a valid
 	// letter. I'm not sure this is the best approach, but it is quite tricky trying
-	// to figure out alhabetical vs. not across encoding. So take a very 
+	// to figure out alhabetical vs. not across encoding. So take a very
 	// conservative approach.
 
 //	if ( encoding == TIXML_ENCODING_UTF8 )
@@ -224,7 +226,7 @@ void TiXmlParsingData::Stamp( const char* now, TiXmlEncoding encoding )
 			case '\r':
 				// bump down to the next line
 				++row;
-				col = 0;				
+				col = 0;
 				// Eat the character
 				++p;
 
@@ -266,11 +268,11 @@ void TiXmlParsingData::Stamp( const char* now, TiXmlEncoding encoding )
 						// In these cases, don't advance the column. These are
 						// 0-width spaces.
 						if ( *(pU+1)==TIXML_UTF_LEAD_1 && *(pU+2)==TIXML_UTF_LEAD_2 )
-							p += 3;	
+							p += 3;
 						else if ( *(pU+1)==0xbfU && *(pU+2)==0xbeU )
-							p += 3;	
+							p += 3;
 						else if ( *(pU+1)==0xbfU && *(pU+2)==0xbfU )
-							p += 3;	
+							p += 3;
 						else
 							{ p +=3; ++col; }	// A normal character.
 					}
@@ -322,10 +324,10 @@ const char* TiXmlBase::SkipWhiteSpace( const char* p, TiXmlEncoding encoding )
 		while ( *p )
 		{
 			const unsigned char* pU = (const unsigned char*)p;
-			
+
 			// Skip the stupid Microsoft UTF-8 Byte order marks
 			if (	*(pU+0)==TIXML_UTF_LEAD_0
-				 && *(pU+1)==TIXML_UTF_LEAD_1 
+				 && *(pU+1)==TIXML_UTF_LEAD_1
 				 && *(pU+2)==TIXML_UTF_LEAD_2 )
 			{
 				p += 3;
@@ -413,12 +415,12 @@ const char* TiXmlBase::ReadName( const char* p, TIXML_STRING * name, TiXmlEncodi
 	// After that, they can be letters, underscores, numbers,
 	// hyphens, or colons. (Colons are valid ony for namespaces,
 	// but tinyxml can't tell namespaces from names.)
-	if (    p && *p 
+	if (    p && *p
 		 && ( IsAlpha( (unsigned char) *p, encoding ) || *p == '_' ) )
 	{
 		const char* start = p;
 		while(		p && *p
-				&&	(		IsAlphaNum( (unsigned char ) *p, encoding ) 
+				&&	(		IsAlphaNum( (unsigned char ) *p, encoding )
 						 || *p == '_'
 						 || *p == '-'
 						 || *p == '.'
@@ -469,7 +471,7 @@ const char* TiXmlBase::GetEntity( const char* p, char* value, int* length, TiXml
 					ucs += mult * (*q - 'a' + 10);
 				else if ( *q >= 'A' && *q <= 'F' )
 					ucs += mult * (*q - 'A' + 10 );
-				else 
+				else
 					return 0;
 				mult *= 16;
 				--q;
@@ -492,7 +494,7 @@ const char* TiXmlBase::GetEntity( const char* p, char* value, int* length, TiXml
 			{
 				if ( *q >= '0' && *q <= '9' )
 					ucs += mult * (*q - '0');
-				else 
+				else
 					return 0;
 				mult *= 10;
 				--q;
@@ -571,10 +573,10 @@ bool TiXmlBase::StringEqual( const char* p,
 	return false;
 }
 
-const char* TiXmlBase::ReadText(	const char* p, 
-									TIXML_STRING * text, 
-									bool trimWhiteSpace, 
-									const char* endTag, 
+const char* TiXmlBase::ReadText(	const char* p,
+									TIXML_STRING * text,
+									bool trimWhiteSpace,
+									const char* endTag,
 									bool caseInsensitive,
 									TiXmlEncoding encoding )
 {
@@ -647,7 +649,7 @@ void TiXmlDocument::StreamIn( std::istream * in, TIXML_STRING * tag )
 	// This "pre-streaming" will never read the closing ">" so the
 	// sub-tag can orient itself.
 
-	if ( !StreamTo( in, '<', tag ) ) 
+	if ( !StreamTo( in, '<', tag ) )
 	{
 		SetError( TIXML_ERROR_PARSING_EMPTY, 0, 0, TIXML_ENCODING_UNKNOWN );
 		return;
@@ -669,7 +671,7 @@ void TiXmlDocument::StreamIn( std::istream * in, TIXML_STRING * tag )
 
 		if ( in->good() )
 		{
-			// We now have something we presume to be a node of 
+			// We now have something we presume to be a node of
 			// some sort. Identify it, and call the node to
 			// continue streaming.
 			TiXmlNode* node = Identify( tag->c_str() + tagIndex, TIXML_DEFAULT_ENCODING );
@@ -778,7 +780,7 @@ const char* TiXmlDocument::Parse( const char* p, TiXmlParsingData* prevData, TiX
 				encoding = TIXML_ENCODING_UTF8;
 			else if ( StringEqual( enc, "UTF8", true, TIXML_ENCODING_UNKNOWN ) )
 				encoding = TIXML_ENCODING_UTF8;	// incorrect, but be nice
-			else 
+			else
 				encoding = TIXML_ENCODING_LEGACY;
 		}
 
@@ -796,7 +798,7 @@ const char* TiXmlDocument::Parse( const char* p, TiXmlParsingData* prevData, TiX
 }
 
 void TiXmlDocument::SetError( int err, const char* pError, TiXmlParsingData* data, TiXmlEncoding encoding )
-{	
+{
 	// The first error in a chain is more accurate - don't set again!
 	if ( error )
 		return;
@@ -832,7 +834,7 @@ TiXmlNode* TiXmlNode::Identify( const char* p, TiXmlEncoding encoding )
 		return 0;
 	}
 
-	// What is this thing? 
+	// What is this thing?
 	// - Elements start with a letter or underscore, but xml is reserved.
 	// - Comments: <!--
 	// - Decleration: <?xml
@@ -915,7 +917,7 @@ void TiXmlElement::StreamIn (std::istream * in, TIXML_STRING * tag)
 			return;
 		}
 		(*tag) += (char) c ;
-		
+
 		if ( c == '>' )
 			break;
 	}
@@ -925,7 +927,7 @@ void TiXmlElement::StreamIn (std::istream * in, TIXML_STRING * tag)
 	// Okay...if we are a "/>" tag, then we're done. We've read a complete tag.
 	// If not, identify and stream.
 
-	if (    tag->at( tag->length() - 1 ) == '>' 
+	if (    tag->at( tag->length() - 1 ) == '>'
 		 && tag->at( tag->length() - 2 ) == '/' )
 	{
 		// All good!
@@ -943,7 +945,7 @@ void TiXmlElement::StreamIn (std::istream * in, TIXML_STRING * tag)
 			StreamWhiteSpace( in, tag );
 
 			// Do we have text?
-			if ( in->good() && in->peek() != '<' ) 
+			if ( in->good() && in->peek() != '<' )
 			{
 				// Yep, text.
 				TiXmlText text( "" );
@@ -976,7 +978,7 @@ void TiXmlElement::StreamIn (std::istream * in, TIXML_STRING * tag)
 						document->SetError( TIXML_ERROR_EMBEDDED_NULL, 0, 0, TIXML_ENCODING_UNKNOWN );
 					return;
 				}
-				
+
 				if ( c == '>' )
 					break;
 
@@ -1095,7 +1097,7 @@ const char* TiXmlElement::Parse( const char* p, TiXmlParsingData* data, TiXmlEnc
 			// Empty tag.
 			if ( *p  != '>' )
 			{
-				if ( document ) document->SetError( TIXML_ERROR_PARSING_EMPTY, p, data, encoding );		
+				if ( document ) document->SetError( TIXML_ERROR_PARSING_EMPTY, p, data, encoding );
 				return 0;
 			}
 			return (p+1);
@@ -1117,7 +1119,7 @@ const char* TiXmlElement::Parse( const char* p, TiXmlParsingData* data, TiXmlEnc
 			// We should find the end tag now
 			// note that:
 			// </foo > and
-			// </foo> 
+			// </foo>
 			// are both valid end tags.
 			if ( StringEqual( p, endTag.c_str(), false, encoding ) )
 			{
@@ -1211,8 +1213,8 @@ const char* TiXmlElement::ReadValue( const char* p, TiXmlParsingData* data, TiXm
 				LinkEndChild( textNode );
 			else
 				delete textNode;
-		} 
-		else 
+		}
+		else
 		{
 			// We hit a '<'
 			// Have we hit a new element or an end tag? This could also be
@@ -1228,7 +1230,7 @@ const char* TiXmlElement::ReadValue( const char* p, TiXmlParsingData* data, TiXm
 				{
 					p = node->Parse( p, data, encoding );
 					LinkEndChild( node );
-				}				
+				}
 				else
 				{
 					return 0;
@@ -1242,7 +1244,7 @@ const char* TiXmlElement::ReadValue( const char* p, TiXmlParsingData* data, TiXm
 	if ( !p )
 	{
 		if ( document ) document->SetError( TIXML_ERROR_READING_ELEMENT_VALUE, 0, 0, encoding );
-	}	
+	}
 	return p;
 }
 
@@ -1252,7 +1254,7 @@ void TiXmlUnknown::StreamIn( std::istream * in, TIXML_STRING * tag )
 {
 	while ( in->good() )
 	{
-		int c = in->get();	
+		int c = in->get();
 		if ( c <= 0 )
 		{
 			TiXmlDocument* document = GetDocument();
@@ -1265,7 +1267,7 @@ void TiXmlUnknown::StreamIn( std::istream * in, TIXML_STRING * tag )
 		if ( c == '>' )
 		{
 			// All is well.
-			return;		
+			return;
 		}
 	}
 }
@@ -1298,7 +1300,7 @@ const char* TiXmlUnknown::Parse( const char* p, TiXmlParsingData* data, TiXmlEnc
 
 	if ( !p )
 	{
-		if ( document )	
+		if ( document )
 			document->SetError( TIXML_ERROR_PARSING_UNKNOWN, 0, 0, encoding );
 	}
 	if ( p && *p == '>' )
@@ -1311,7 +1313,7 @@ void TiXmlComment::StreamIn( std::istream * in, TIXML_STRING * tag )
 {
 	while ( in->good() )
 	{
-		int c = in->get();	
+		int c = in->get();
 		if ( c <= 0 )
 		{
 			TiXmlDocument* document = GetDocument();
@@ -1322,12 +1324,12 @@ void TiXmlComment::StreamIn( std::istream * in, TIXML_STRING * tag )
 
 		(*tag) += (char) c;
 
-		if ( c == '>' 
+		if ( c == '>'
 			 && tag->at( tag->length() - 2 ) == '-'
 			 && tag->at( tag->length() - 3 ) == '-' )
 		{
 			// All is well.
-			return;		
+			return;
 		}
 	}
 }
@@ -1363,11 +1365,11 @@ const char* TiXmlComment::Parse( const char* p, TiXmlParsingData* data, TiXmlEnc
 	//
 	// from the XML spec:
 	/*
-	 [Definition: Comments may appear anywhere in a document outside other markup; in addition, 
-	              they may appear within the document type declaration at places allowed by the grammar. 
-				  They are not part of the document's character data; an XML processor MAY, but need not, 
-				  make it possible for an application to retrieve the text of comments. For compatibility, 
-				  the string "--" (double-hyphen) MUST NOT occur within comments.] Parameter entity 
+	 [Definition: Comments may appear anywhere in a document outside other markup; in addition,
+	              they may appear within the document type declaration at places allowed by the grammar.
+				  They are not part of the document's character data; an XML processor MAY, but need not,
+				  make it possible for an application to retrieve the text of comments. For compatibility,
+				  the string "--" (double-hyphen) MUST NOT occur within comments.] Parameter entity
 				  references MUST NOT be recognized within comments.
 
 				  An example of a comment:
@@ -1382,7 +1384,7 @@ const char* TiXmlComment::Parse( const char* p, TiXmlParsingData* data, TiXmlEnc
 		value.append( p, 1 );
 		++p;
 	}
-	if ( p && *p ) 
+	if ( p && *p )
 		p += strlen( endTag );
 
 	return p;
@@ -1421,7 +1423,7 @@ const char* TiXmlAttribute::Parse( const char* p, TiXmlParsingData* data, TiXmlE
 		if ( document ) document->SetError( TIXML_ERROR_READING_ATTRIBUTES, p, data, encoding );
 		return 0;
 	}
-	
+
 	const char* end;
 	const char SINGLE_QUOTE = '\'';
 	const char DOUBLE_QUOTE = '\"';
@@ -1450,7 +1452,7 @@ const char* TiXmlAttribute::Parse( const char* p, TiXmlParsingData* data, TiXmlE
 		{
 			if ( *p == SINGLE_QUOTE || *p == DOUBLE_QUOTE ) {
 				// [ 1451649 ] Attribute values with trailing quotes not handled correctly
-				// We did not have an opening quote but seem to have a 
+				// We did not have an opening quote but seem to have a
 				// closing one. Give up and throw an error.
 				if ( document ) document->SetError( TIXML_ERROR_READING_ATTRIBUTES, p, data, encoding );
 				return 0;
@@ -1467,8 +1469,8 @@ void TiXmlText::StreamIn( std::istream * in, TIXML_STRING * tag )
 {
 	while ( in->good() )
 	{
-		int c = in->peek();	
-		if ( !cdata && (c == '<' ) ) 
+		int c = in->peek();
+		if ( !cdata && (c == '<' ) )
 		{
 			return;
 		}
@@ -1489,7 +1491,7 @@ void TiXmlText::StreamIn( std::istream * in, TIXML_STRING * tag )
 				// terminator of cdata.
 				return;
 			}
-		}    
+		}
 	}
 }
 #endif
@@ -1529,7 +1531,7 @@ const char* TiXmlText::Parse( const char* p, TiXmlParsingData* data, TiXmlEncodi
 			++p;
 		}
 
-		TIXML_STRING dummy; 
+		TIXML_STRING dummy;
 		p = ReadText( p, &dummy, false, endTag, false, encoding );
 		return p;
 	}
@@ -1603,19 +1605,19 @@ const char* TiXmlDeclaration::Parse( const char* p, TiXmlParsingData* data, TiXm
 		if ( StringEqual( p, "version", true, _encoding ) )
 		{
 			TiXmlAttribute attrib;
-			p = attrib.Parse( p, data, _encoding );		
+			p = attrib.Parse( p, data, _encoding );
 			version = attrib.Value();
 		}
 		else if ( StringEqual( p, "encoding", true, _encoding ) )
 		{
 			TiXmlAttribute attrib;
-			p = attrib.Parse( p, data, _encoding );		
+			p = attrib.Parse( p, data, _encoding );
 			encoding = attrib.Value();
 		}
 		else if ( StringEqual( p, "standalone", true, _encoding ) )
 		{
 			TiXmlAttribute attrib;
-			p = attrib.Parse( p, data, _encoding );		
+			p = attrib.Parse( p, data, _encoding );
 			standalone = attrib.Value();
 		}
 		else

--- a/src/tinyxml/tinyxmlparser.cpp
+++ b/src/tinyxml/tinyxmlparser.cpp
@@ -111,17 +111,21 @@ void TiXmlBase::ConvertUTF32ToUTF8( unsigned long input, char* output, int* leng
 			--output;
 			*output = (char)((input | BYTE_MARK) & BYTE_MASK);
 			input >>= 6;
+			[[fallthrough]];
 		case 3:
 			--output;
 			*output = (char)((input | BYTE_MARK) & BYTE_MASK);
 			input >>= 6;
+			[[fallthrough]];
 		case 2:
 			--output;
 			*output = (char)((input | BYTE_MARK) & BYTE_MASK);
 			input >>= 6;
+			[[fallthrough]];
 		case 1:
 			--output;
 			*output = (char)(input | FIRST_BYTE_MARK[*length]);
+			[[fallthrough]];
 		default:
 			break;
 	}

--- a/src/titlerender.cpp
+++ b/src/titlerender.cpp
@@ -20,12 +20,12 @@ int tb;
 
 std::string tempstring;
 
-void updategraphicsmode(Game& game, Graphics& dwgfx)
+void updategraphicsmode()
 {
     swfStage = stage;
 }
 
-void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, UtilityClass& help, musicclass& music)
+void titlerender(Graphics& dwgfx, mapclass& map, Game& game, UtilityClass& help, musicclass& music)
 {
 
     FillRect(dwgfx.backBuffer, 0,0,dwgfx.backBuffer->w, dwgfx.backBuffer->h, 0x00000000 );
@@ -1233,7 +1233,7 @@ void titlerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, U
     //dwgfx.backbuffer.unlock();
 }
 
-void gamecompleterender(Graphics& dwgfx, Game& game, entityclass& obj, UtilityClass& help, mapclass& map)
+void gamecompleterender(Graphics& dwgfx, Game& game, UtilityClass& help, mapclass& map)
 {
     //dwgfx.backbuffer.lock();
     FillRect(dwgfx.backBuffer, 0x000000);
@@ -1445,7 +1445,7 @@ void gamecompleterender(Graphics& dwgfx, Game& game, entityclass& obj, UtilityCl
     //dwgfx.backbuffer.unlock();
 }
 
-void gamecompleterender2(Graphics& dwgfx, Game& game, entityclass& obj, UtilityClass& help)
+void gamecompleterender2(Graphics& dwgfx, Game& game)
 {
     //dwgfx.backbuffer.lock();
     FillRect(dwgfx.backBuffer, 0x000000);
@@ -1546,7 +1546,7 @@ void gamerender(Graphics& dwgfx, mapclass& map, Game& game, entityclass& obj, Ut
                 }
 
                 //Animate the entities
-                obj.animateentities(i, game, help);
+                obj.animateentities(i, game);
             }
         }
 
@@ -2790,7 +2790,7 @@ void towerrender(Graphics& dwgfx, Game& game, mapclass& map, entityclass& obj, U
             }
 
             //Animate the entities
-            obj.animateentities(i, game, help);
+            obj.animateentities(i, game);
         }
     }
 


### PR DESCRIPTION
Whole bunch of unused parameters, a switch statement with implicit fall through and some PhysFS deprecated function calls.

Bonus features: More aggressive crashing for easier diagnosis and automatically fetch `data.zip`.